### PR TITLE
Fixed typo in Bash Prog Intro How-to

### DIFF
--- a/LDP/howto/linuxdoc/Bash-Prog-Intro-HOWTO.sgml
+++ b/LDP/howto/linuxdoc/Bash-Prog-Intro-HOWTO.sgml
@@ -156,8 +156,8 @@ All about redirection
 
 	<sect1>
 	Sample: stdout 2 stderr
-	<p> This will cause the stderr ouput of a program to be written to the same filedescriptor 
-	than stdout.
+	<p> This will cause the stdout ouput of a program to be written to the same filedescriptor 
+	than stderr.
 	<tscreen><verb>
 	grep da * 1>&2 
 	</verb></tscreen>


### PR DESCRIPTION
Sections 3.4 and 3.5 start with the same sentence but I think it's a copy-paste typo...