### PR TITLE
Grammar/spelling fixes for Bash Prog Intro

### DIFF
--- a/LDP/howto/linuxdoc/Bash-Prog-Intro-HOWTO.sgml
+++ b/LDP/howto/linuxdoc/Bash-Prog-Intro-HOWTO.sgml
@@ -1,6 +1,6 @@
 <!doctype linuxdoc system>
 
-<!-- 
+<!--
      An introduction to bash shell programming
  -->
 
@@ -9,16 +9,16 @@
 <article>
     <title>BASH Programming - Introduction HOW-TO</title>
     <author>by Mike G <tt/mikkey at dynamo.com.ar/</author>
-    <date> 
+    <date>
 	Thu Jul 27 09:36:18 ART 2000
     </date>
-    <abstract> 
-    This article intends to help you to start programming 
-    basic-intermediate shell scripts. It does not intend to be an 
-    advanced document (see the title). I am NOT an expert nor guru 
-    shell programmer. I decided to write this because I'll learn a 
-    lot and it might be useful to other people. Any feedback will be apreciated, 
-    specially in the patch form :) 
+    <abstract>
+    This article is intended to help you to start programming
+    basic-intermediate shell scripts. It does not intend to be an
+    advanced document (see the title). I am NOT an expert nor guru
+    shell programmer. I decided to write this because I'll learn a
+    lot and it might be useful to other people. Any feedback will is
+    appreciated, especially in the patch or pull request form. :)
     </abstract>
 
 <!-- Table of contents -->
@@ -41,73 +41,73 @@ Getting the latest version
 
      <sect1>
      Requisites
-          <P> Familiarity with GNU/Linux command lines, and familiarity 
+          <P> Familiarity with GNU/Linux command lines, and familiarity
           with basic programming concepts is helpful. While this is not
           a programming introduction, it explains (or at least tries) many
           basic concepts.
-          <P> 
+          <P>
      </sect1>
      <sect1>
      Uses of this document
           <P> This document tries to be useful in the following situations
 	  <itemize>
-	      <item> You have an idea about programming and you want to start 
+	      <item> You have an idea about programming and you want to start
 	      coding some shell scripts.
-	      <item> You have a vague idea about shell programming and want 
+	      <item> You have a vague idea about shell programming and want
 	      some sort of reference.
 	      <item> You want to see some shell scripts and some comments to
-	      start writing your own
-	      <item> You are migrating from DOS/Windows (or already did) 
+	      start writing your own.
+	      <item> You are migrating from DOS/Windows (or already did)
 	      and want to make "batch" processes.
-	      <item> You are a complete nerd and read every how-to available
+	      <item> You are a complete nerd and read every how-to available.
 	  </itemize>
      </sect1>
 </sect>
 
-<!-- Very simple Scripts --> 
+<!-- Very simple Scripts -->
 <sect>
 Very simple Scripts
 
     <P> This HOW-TO will try to give you some hints about shell script
     programming strongly based on examples.
-    <P> In this section you'll find some little scripts which 
+    <P> In this section you'll find some little scripts which
     will hopefully help you to understand some techniques.
 
     <sect1>
     Traditional hello world script
 
         <!-- __TO-DO__
-	someone suggested using this instead of the line numbering 
+	someone suggested using this instead of the line numbering
 	but it doesn't work on verion 1.0.9
-	<pre></pre> 
+	<pre></pre>
 	-->
 	<P>
 	<tscreen><verb>
-	  #!/bin/bash          
-	  echo Hello World    
+	  #!/bin/bash
+	  echo Hello World
 	</verb></tscreen>
-	<P> 
-	<P> This script has only two lines. 
-        The first indicates the system which program 
-        to use to run the file. 
-        <P> The second line is the only action performed by this script, 
+	<P>
+	<P> This script has only two lines.
+        The first indicates the system which program
+        to use to run the file.
+        <P> The second line is the only action performed by this script,
         which prints 'Hello World' on the terminal.
 	<P> If you get something like <it>./hello.sh: Command not found.</it>
-	Probably the first line '#!/bin/bash' is wrong, issue whereis bash or see 
-	'finding bash' to see how sould you write this line. 
+	Probably the first line '#!/bin/bash' is wrong, issue whereis bash or see
+	'finding bash' to see how should you write this line.
     </sect1>
     <sect1>
     A very simple backup script
         <P>
 	<tscreen><verb>
-	#!/bin/bash          
+	#!/bin/bash
 	tar -cZf /var/my-backup.tgz /home/me/
 	</verb></tscreen>
-        <P> In this script, instead of printing a message on the terminal, 
+        <P> In this script, instead of printing a message on the terminal,
 	we create a tar-ball of a user's home directory. This is NOT intended
-	to be used, a more useful backup script is presented later in this 
+	to be used, a more useful backup script is presented later in this
         document.
-    </sect1>   
+    </sect1>
 </sect>
 
 <!-- Redirection -->
@@ -122,31 +122,32 @@ All about redirection
 	<enum>
 	<item> redirect stdout to a file
 	<item> redirect stderr to a file
-	<item> redirect stdout to a stderr 
-	<item> redirect stderr to a stdout 
-	<item> redirect stderr and stdout to a file 
-	<item> redirect stderr and stdout to stdout 
+	<item> redirect stdout to a stderr
+	<item> redirect stderr to a stdout
+	<item> redirect stderr and stdout to a file
+	<item> redirect stderr and stdout to stdout
 	<item> redirect stderr and stdout to stderr
 	</enum>
 	1 'represents' stdout and 2 stderr.
-	<p> A little note for seeing this things: with the less command you can view both stdout 
-	(which will remain on the buffer) and the stderr that will be printed on the screen, but erased as 
-	you try to 'browse' the buffer. 
+	<p> A little note for seeing the output of these commands: with the less
+    command you can view both stdout (which will remain on the buffer) and the
+    stderr that will be printed on the screen, but erased as you try to 'browse'
+    the buffer.
 	</sect1>
-	
+
 	<sect1>
-	Sample: stdout 2 file 
-	<p> This will cause the ouput of a program to be written to a file.
+	Sample: stdout 2 file
+	<p> This will cause the output of a program to be written to a file.
 	<tscreen><verb>
 	ls -l > ls-l.txt
 	</verb></tscreen>
-	Here, a file called 'ls-l.txt' will be created and it will contain what you would see on the 
+	Here, a file called 'ls-l.txt' will be created and it will contain what you would see on the
 	screen if you type the command 'ls -l' and execute it.
 	</sect1>
 
 	<sect1>
-	Sample: stderr 2 file 
-	<p> This will cause the stderr ouput of a program to be written to a file.
+	Sample: stderr 2 file
+	<p> This will cause the stderr output of a program to be written to a file.
 	<tscreen><verb>
 	grep da * 2> grep-errors.txt
 	</verb></tscreen>
@@ -156,38 +157,38 @@ All about redirection
 
 	<sect1>
 	Sample: stdout 2 stderr
-	<p> This will cause the stdout ouput of a program to be written to the same filedescriptor 
+	<p> This will cause the stdout output of a program to be written to the same filedescriptor
 	as stderr.
 	<tscreen><verb>
-	grep da * 1>&2 
+	grep da * 1>&2
 	</verb></tscreen>
-	Here, the stdout portion of the command is sent to stderr, you may notice that in differen ways.
+	Here, the stdout portion of the command is sent to stderr, you may notice that in different ways.
 	</sect1>
 
 	<sect1>
-	Sample: stderr 2 stdout 
-	<p> This will cause the stderr ouput of a program to be written to the same filedescriptor 
+	Sample: stderr 2 stdout
+	<p> This will cause the stderr output of a program to be written to the same filedescriptor
 	as stdout.
 	<tscreen><verb>
 	grep * 2>&1
 	</verb></tscreen>
 	Here, the stderr portion of the command is sent to stdout, if you pipe to less, you'll see that
-	lines that normally 'dissapear' (as they are written to stderr) are being kept now (because
-	they're on stdout). 
+	lines that normally 'disappear' (as they are written to stderr) are being kept now (because
+	they're on stdout).
 	</sect1>
 
 	<sect1>
-	Sample: stderr and stdout 2 file 
-	<p> This will place every output of a program to a file. This is suitable sometimes 
-	for cron entries, if you want a command to pass in absolute silence.  
+	Sample: stderr and stdout 2 file
+	<p> This will place every output of a program to a file. This is suitable sometimes
+	for cron entries, if you want a command to pass in absolute silence.
 	<tscreen><verb>
-	rm -f $(find / -name core) &> /dev/null 
+	rm -f $(find / -name core) &> /dev/null
 	</verb></tscreen>
 	This (thinking on the cron entry) will delete every file called 'core' in any directory. Notice
-	 that you should be pretty sure of what a command is doing if you are going to wipe it's output. 
+	 that you should be pretty sure of what a command is doing if you are going to wipe it's output.
 	</sect1>
 <!--
-redirect stderr and stdout to stdout 
+redirect stderr and stdout to stdout
 redirect stderr and stdout to stderr
 -->
 
@@ -195,8 +196,8 @@ redirect stderr and stdout to stderr
 
 <!--
 	<sect1>
-	Sample: 
-	<p> This will 
+	Sample:
+	<p> This will
 	<tscreen><verb>
 	command
 	</verb></tscreen>
@@ -209,35 +210,35 @@ redirect stderr and stdout to stderr
 <!-- pipes -->
 <sect>
 Pipes
-	<p> This section explains in a very simple and practical way how to use pipes, 
-	nd why you may want it.
+	<p> This section explains in a very simple and practical way how to use pipes,
+	and why you may want to use them.
 
 	<sect1>
 	What they are and why you'll want to use them
-		<p> Pipes let you use (very simple, I insist) the output of a program as the 
-		input of another one	
+		<p> Pipes let you use (very simple, I insist) the output of a program as the
+		input of another one
 	</sect1>
 
 
 	<sect1>
-	Sample: simple pipe with sed 
+	Sample: simple pipe with sed
 	<p> This is very simple way to use pipes.
 	<tscreen><verb>
-	ls -l | sed -e "s/[aeio]/u/g"	
+	ls -l | sed -e "s/[aeio]/u/g"
 	</verb></tscreen>
-	Here, the following happens: first the command ls -l is executed, and it's output, 
+	Here, the following happens: first the command ls -l is executed, and its output,
 	instead of being printed, is sent (piped) to the sed program, which in turn, prints
-	what it has to. 
+	what it has to.
 	</sect1>
 
 	<sect1>
-	Sample: an alternative to ls -l *.txt 
+	Sample: an alternative to ls -l *.txt
 	<p> Probably, this is a more difficult way to do ls -l *.txt, but it is here for illustrating pipes,
-	not for solving such listing dilema. 
+	not for solving such listing dillema.
 	<tscreen><verb>
 	ls -l | grep "\.txt$"
 	</verb></tscreen>
-	Here, the output of the program ls -l is sent to the grep program, which, in turn, will print 
+	Here, the output of the program ls -l is sent to the grep program, which, in turn, will print
 	lines which match the regex "\.txt$".
 	</sect1>
 
@@ -245,8 +246,8 @@ Pipes
 
 <!--
 	<sect1>
-	Sample: 
-	<p> This will 
+	Sample:
+	<p> This will
 	<tscreen><verb>
 	command
 	</verb></tscreen>
@@ -265,47 +266,47 @@ Pipes
 Variables
 
     <!-- Dry Theory -->
-        <P> You can use variables as in any programming languages. 
+        <P> You can use variables as in any programming languages.
 	There are no data types. A variable in bash can contain a number, a
-	character, a string of characters. 
-	<P>  You have no need to declare a variable, just 
+	character, a string of characters.
+	<P>  You have no need to declare a variable, just
         assigning a value to its reference will create it.
 
-	
+
 
     <!-- Samples -->
         <sect1>
 	Sample: Hello World! using variables
-            <P> 
+            <P>
 	    <tscreen><verb>
-	    #!/bin/bash          
+	    #!/bin/bash
 	    STR="Hello World!"
-	    echo $STR    
+	    echo $STR
 	    </verb></tscreen>
 
-	    <P> Line 2 creates 
+	    <P> Line 2 creates
 	    a variable called STR and assigns the string "Hello World!" to
-	    it. Then the VALUE of this variable is retrieved by putting 
-	    the '$' in at the beginning. Please notice (try it!) 
+	    it. Then the VALUE of this variable is retrieved by putting
+	    the '$' in at the beginning. Please notice (try it!)
 	    that if you don't use the '$' sign, the output of the program will
 	    be different, and probably not what you want it to be.
 	</sect1>
 
         <sect1>
 	   Sample: A very simple backup script (little bit better)
-	   <P> 
+	   <P>
 	   <tscreen><verb>
-	   #!/bin/bash          
+	   #!/bin/bash
 	   OF=/var/my-backup-$(date +%Y%m%d).tgz
 	   tar -cZf $OF /home/me/
 	   </verb></tscreen>
-	   <P> This script introduces another thing. First 
-	   of all, you should be familiarized with the variable 
+	   <P> This script introduces another thing. First
+	   of all, you should be familiarized with the variable
 	   creation and assignation on line 2. Notice the expression
 	   '$(date +%Y%m%d)'.
-	   If you run the script you'll notice that 
+	   If you run the script you'll notice that
 	   it runs the
-	   command inside the parenthesis, capturing its output. 
+	   command inside the parenthesis, capturing its output.
 
 	   <P> Notice that in this script, the output filename will
 	   be different every day, due to the format switch to the date command(+%Y%m%d).
@@ -313,7 +314,7 @@ Variables
 	   <P> Some more examples:
 	   <P> echo ls
 	   <P> echo $(ls)
-	</sect1>  
+	</sect1>
 
 	<sect1>
 	Local variables
@@ -322,7 +323,7 @@ Variables
 
 	<tscreen><verb>
 		#!/bin/bash
-		HELLO=Hello 
+		HELLO=Hello
 		function hello {
 			local HELLO=World
 			echo $HELLO
@@ -331,16 +332,16 @@ Variables
 		hello
 		echo $HELLO
 	</verb></tscreen>
-	<p> This example should be enought to show how to use a local variable. 
+	<p> This example should be enought to show how to use a local variable.
 	</sect1>
- 
+
 </sect>
 
 <!-- Conditionals -->
 <sect>
 Conditionals
-    
-    <P> Conditionals let you decide whether to perform an action 
+
+    <P> Conditionals let you decide whether to perform an action
     or not, this decision is taken by evaluating an expression.
 
     <!-- Dry Theory -->
@@ -348,23 +349,23 @@ Conditionals
     Dry Theory
         <P> Conditionals have many forms. The most basic form is:
 	<bf>if</bf> <it/expression/ <bf>then</bf> <it/statement/
-	where 'statement' is only executed if 'expression' 	
+	where 'statement' is only executed if 'expression'
 	evaluates to true.
-	'2<1' is an expresion that evaluates to false, while '2>1' 
+	'2<1' is an expresion that evaluates to false, while '2>1'
 	evaluates to true.xs
 	<p> Conditionals have other forms such as:
-	<bf/if/ <it/expression/ 
+	<bf/if/ <it/expression/
 	<bf/then/ <it/statement1/ <bf/else/ <it/statement2/.
 	 Here 'statement1' is executed  if 'expression' is true,otherwise
 	'statement2' is executed.
-	<P> Yet another form of conditionals is:  
-	<bf/if/ <it/expression1/ 
-	<bf/then/ <it/statement1/ 
-	<bf/else if/ <it/expression2/ <bf/then/ <it/statement2/ 
+	<P> Yet another form of conditionals is:
+	<bf/if/ <it/expression1/
+	<bf/then/ <it/statement1/
+	<bf/else if/ <it/expression2/ <bf/then/ <it/statement2/
 	<bf/else/ <it/statement3/.
 	In this form there's added only the
 	"ELSE IF 'expression2' THEN 'statement2'" which makes statement2 being
-	executed if expression2 evaluates to true. The rest is as you may 
+	executed if expression2 evaluates to true. The rest is as you may
 	imagine (see previous forms).
 	<P> A word about syntax:
 	<P> The base for the 'if' constructions in bash is this:
@@ -376,16 +377,16 @@ Conditionals
     <!-- Samples -->
         <sect1>
 	Sample: Basic conditional example if .. then
-            <P> 
+            <P>
 	    <tscreen><verb>
 	    #!/bin/bash
 	    if [ "foo" = "foo" ]; then
 	       echo expression evaluated as true
 	    fi
 	    </verb></tscreen>
-	    <P> The code to be executed if the expression within braces 
-	    is true can 
-	    be found after the 'then' word and before 'fi' which indicates the end 
+	    <P> The code to be executed if the expression within braces
+	    is true can
+	    be found after the 'then' word and before 'fi' which indicates the end
 	    of the conditionally executed code.
 	</sect1>
 	<sect1>
@@ -402,7 +403,7 @@ Conditionals
 	</sect1>
 	<sect1>
 	Sample: Conditionals with variables
-	    <P> 
+	    <P>
 	    <tscreen><verb>
 	    #!/bin/bash
 	    T1="foo"
@@ -416,8 +417,8 @@ Conditionals
 	</sect1>
 <!--
 	<sect1>
-	Sample: testing if a file exists 
-	    <P> one more thank to mike 
+	Sample: testing if a file exists
+	    <P> one more thank to mike
 	    <tscreen><verb>
 	    #!/bin/bash
 	    FILE=~/.basrc
@@ -440,7 +441,7 @@ Loops for, while and until
 
     <P> In this section you'll find for, while and until loops.
     <P> The <bf/for/ loop is a little bit different from other programming
-    languages. Basically, it let's you iterate over a series of 
+    languages. Basically, it let's you iterate over a series of
     'words' within a string.
       <P> The <bf/while/ executes a piece of code if the control expression
       is true, and only stops when it is false (or a explicit break is found
@@ -448,22 +449,22 @@ Loops for, while and until
       <P> The <bf/until/ loop is almost equal to the while loop, except that
       the code is executed while the control expression evaluates to false.
       <P> If you suspect that while and until are very similar you are right.
-    <!-- Samples -->    
+    <!-- Samples -->
     <sect1>
     For sample
-        <P> 
+        <P>
 	<tscreen><verb>
         #!/bin/bash
         for i in $( ls ); do
             echo item: $i
         done
         </verb></tscreen>
-        <p> 
+        <p>
         <p> On the second line, we declare i to be the variable that
-	 will take the 
+	 will take the
         different values contained in $( ls ).
         <p> The third line could be longer if needed, or there could
-	 be more lines 
+	 be more lines
         before the done (4).
         <p> 'done' (4) indicates that the code that used the value of $i has
         finished and $i can take a new value.
@@ -481,29 +482,29 @@ Loops for, while and until
 	for i in `seq 1 10`;
 	do
 		echo $i
-	done	
+	done
 	</verb></tscreen>
 	</sect1>
     <!-- while -->
     <sect1>
     While sample
          <P> <tscreen><verb>
-         #!/bin/bash 
+         #!/bin/bash
          COUNTER=0
          while [  $COUNTER -lt 10 ]; do
              echo The counter is $COUNTER
-             let COUNTER=COUNTER+1 
+             let COUNTER=COUNTER+1
          done
          </verb></tscreen>
 	 <P>
-	 <P> This script 'emulates' the well known 
+	 <P> This script 'emulates' the well known
 	 (C, Pascal, perl, etc) 'for' structure
     </sect1>
     <!-- until -->
     <sect1>
     Until sample
          <P> <tscreen><verb>
-         #!/bin/bash 
+         #!/bin/bash
          COUNTER=20
          until [  $COUNTER -lt 10 ]; do
              echo COUNTER $COUNTER
@@ -516,7 +517,7 @@ Loops for, while and until
 <!-- Functions -->
 <sect>
 Functions
-     <P> As in almost any programming language, you can use functions to group 
+     <P> As in almost any programming language, you can use functions to group
      pieces of code in a more logical way or practice the divine art of recursion.
      <P> Declaring a function is just a matter of writing function my_func { my_code }.
      <P> Calling a function is just like calling another program, you just write its name.
@@ -524,7 +525,7 @@ Functions
      <sect1>
      Functions sample
            <P> <tscreen><verb>
-	   #!/bin/bash 
+	   #!/bin/bash
 	   function quit {
 	       exit
 	   }
@@ -533,33 +534,33 @@ Functions
 	   }
 	   hello
 	   quit
-	   echo foo 
+	   echo foo
 	   </verb></tscreen>
 	   <P> Lines 2-4 contain the 'quit' function. Lines 5-7 contain the 'hello' function
 	   If you are not absolutely sure about what this script does, please try it!.
 	   <P> Notice that a functions don't need to be declared in any specific order.
-	   <P> When running the script you'll notice that first: the function 'hello' is 
+	   <P> When running the script you'll notice that first: the function 'hello' is
 	   called, second the 'quit' function, and the program never reaches line 10.
      </sect1>
 
      <sect1>
      Functions with parameters sample
            <P> <tscreen><verb>
-		#!/bin/bash 
+		#!/bin/bash
 		function quit {
  		   exit
-		}  
+		}
 		function e {
-		    echo $1 
-		}  
+		    echo $1
+		}
 		e Hello
 		e World
 		quit
-		echo foo 
+		echo foo
 
 	   </verb></tscreen>
-	   <P> This script is almost identically to the previous one. The main difference is the 
-		funcion 'e'. This function, prints the first argument it receives. 
+	   <P> This script is almost identically to the previous one. The main difference is the
+		funcion 'e'. This function, prints the first argument it receives.
 		Arguments, within funtions, are treated in the same manner as arguments given to the script.
      </sect1>
 
@@ -588,20 +589,20 @@ User interfaces
 	   	echo bad option
 	       fi
 	   done
-	  </verb></tscreen> 
-           <P> If you run this script you'll see that it is a 
-           programmer's dream for text based menus. You'll probably notice 
-           that it's very similar to the 'for' construction, only rather 
+	  </verb></tscreen>
+           <P> If you run this script you'll see that it is a
+           programmer's dream for text based menus. You'll probably notice
+           that it's very similar to the 'for' construction, only rather
            than looping for each 'word' in $OPTIONS, it prompts the user.
 	   <P>
      </sect1>
     <!-- Using the command line -->
     <sect1>
-    Using the command line 
+    Using the command line
          <P>
 	 <tscreen><verb>
-	  #!/bin/bash        
-          if [ -z "$1" ]; then 
+	  #!/bin/bash
+          if [ -z "$1" ]; then
               echo usage: $0 directory
               exit
           fi
@@ -611,7 +612,7 @@ User interfaces
           tar -cZf $TGTD$OF $SRCD
 	 </verb></tscreen>
 	 <P>
-	 <P> What this script does should be clear to you. The expression 
+	 <P> What this script does should be clear to you. The expression
 	 in the first conditional tests if the program has received an argument
 	 ($1) and quits if it didn't, showing the user a little usage message.
 	 The rest of the script should be clear at this point.
@@ -622,11 +623,11 @@ User interfaces
 <!-- Misc -->
 <sect>
 Misc
-    <!-- Reading user input  -->    
+    <!-- Reading user input  -->
     <sect1>
     Reading user input with read
-         <P> In many ocations you may want to prompt the user for some input, and 
-		there are several ways 
+         <P> In many ocations you may want to prompt the user for some input, and
+		there are several ways
 		to achive this. This is one of those ways:
 	<tscreen><verb>
 		#!/bin/bash
@@ -634,23 +635,23 @@ Misc
 		read NAME
 		echo "Hi $NAME!"
 	</verb></tscreen>
-	<P> As a variant, you can get multiple values with read, this example may 
+	<P> As a variant, you can get multiple values with read, this example may
 	clarify this.
 	<tscreen><verb>
 		#!/bin/bash
 		echo Please, enter your firstname and lastname
-		read FN LN 
+		read FN LN
 		echo "Hi! $LN, $FN !"
 	</verb></tscreen>
-	
+
     </sect1>
 
-    <!-- Arithmetic evaluation  -->    
+    <!-- Arithmetic evaluation  -->
     <sect1>
     Arithmetic evaluation
          <P> On the command line (or a shell) try this:
 	 <P> echo 1 + 1
-	 <P> If you expected to see '2' you'll be disappointed. What if 
+	 <P> If you expected to see '2' you'll be disappointed. What if
 	 you want BASH to evaluate some numbers you have? The solution
 	 is this:
 	 <P> echo $((1+1))
@@ -658,17 +659,17 @@ Misc
 	 arithmetic expression. You can achieve this also like this:
 	 <P> echo $[1+1]
 	 <P>
-	 <P> If you need to use fractions, or more math or you just want it, you 
+	 <P> If you need to use fractions, or more math or you just want it, you
 	 can use bc to evaluate arithmetic expressions.
-	 <P> if i ran "echo $[3/4]" at the command prompt, it would return 0 
+	 <P> if i ran "echo $[3/4]" at the command prompt, it would return 0
 	 because bash  only uses integers when answering. If you  ran
 	  "echo 3/4|bc -l", it would properly return 0.75.
     </sect1>
 
 
     <sect1>
-    Finding bash  
-        <P> From a message from mike (see Thanks to) 
+    Finding bash
+        <P> From a message from mike (see Thanks to)
         <P> you always use #!/bin/bash .. you might was to give an example of
         <P> how to find where bash is located.
         <P> 'locate bash' is preferred, but not all machines have locate.
@@ -685,7 +686,7 @@ Misc
 	<P> You may try also 'which bash'.
    </sect1>
 
-    <!-- Capturing a commands output  -->    
+    <!-- Capturing a commands output  -->
     <sect1>
     Getting the return value of a program
         <P> In bash, the return value of a program is stored in a special variable called $?.
@@ -699,12 +700,12 @@ Misc
 	echo rv: $?
 	</verb> </tscreen>
     </sect1>
- 
- 
-    <!-- Capturing a commands output  -->    
+
+
+    <!-- Capturing a commands output  -->
     <sect1>
-    Capturing a commands output 
-         <P> This little scripts show all tables from all databases (assuming you got MySQL installed). 
+    Capturing a commands output
+         <P> This little scripts show all tables from all databases (assuming you got MySQL installed).
 	Also, consider changing the 'mysql' command to use a valid username and password.
 	<tscreen><verb>
 	#!/bin/bash
@@ -715,11 +716,11 @@ Misc
 	done
 	</verb></tscreen>
     </sect1>
-    
+
     <!-- Multiple source files -->
     <sect1>
     Multiple source files
-        <P> You can use multiple files with the command source. 
+        <P> You can use multiple files with the command source.
 	<P> __TO-DO__
     </sect1>
 </sect>
@@ -731,25 +732,25 @@ Tables
     <!-- String operators -->
     <sect1>
     String comparison operators
-    
+
     <P> (1) s1 = s2
     <P> (2) s1 != s2
     <P> (3) s1 < s2
     <P> (4) s1 > s2
-    <P> (5) -n s1 
-    <P> (6) -z s1 
-    <P> 
+    <P> (5) -n s1
+    <P> (6) -z s1
+    <P>
     <P> (1) s1 matches s2
     <P> (2) s1 does not match s2
     <P> (3) __TO-DO__
     <P> (4) __TO-DO__
     <P> (5) s1 is not null (contains one or more characters)
-    <P> (6) s1 is null 
+    <P> (6) s1 is null
     </sect1>
 
 	<sect1>
 	String comparison examples
-	<p> Comparing two strings. 
+	<p> Comparing two strings.
 	<tscreen><verb>
 	#!/bin/bash
 	S1='string'
@@ -770,7 +771,7 @@ Tables
 
 	</sect1>
 
-    <!-- Arithmetic operators -->    
+    <!-- Arithmetic operators -->
     <sect1>
     Arithmetic operators
     <P> +
@@ -780,47 +781,47 @@ Tables
     <P> % (remainder)
     </sect1>
 
-    <!-- Arithmetic relational operators -->    
+    <!-- Arithmetic relational operators -->
     <sect1>
     Arithmetic relational operators
-    <P> -lt (<) 
+    <P> -lt (<)
     <P> -gt (>)
     <P> -le (<=)
     <P> -ge (>=)
     <P> -eq (==)
     <P> -ne (!=)
-    <P> C programmer's should simple map the operator to its corresponding 
+    <P> C programmer's should simple map the operator to its corresponding
     parenthesis.
     </sect1>
-    
 
-    <!-- Useful commands  -->    
+
+    <!-- Useful commands  -->
     <sect1>
     Useful commands
-         <P> This section was re-written by Kees (see thank to...) 
-	 <P>  Some of these command's almost contain complete programming languages. 
-	From those commands only the basics will be explained. For a more detailed 
+         <P> This section was re-written by Kees (see thank to...)
+	 <P>  Some of these command's almost contain complete programming languages.
+	From those commands only the basics will be explained. For a more detailed
 	description, have a closer look at the man pages of each command.
 
 	<bf/sed/ (stream editor)
 
-   	<P> Sed is a non-interactive editor. Instead of altering a file by moving the 
-	cursor on the screen, you use a script of editing instructions to sed, plus the 
-	name of the file to edit. You can also describe sed as a filter. Let's have 
+   	<P> Sed is a non-interactive editor. Instead of altering a file by moving the
+	cursor on the screen, you use a script of editing instructions to sed, plus the
+	name of the file to edit. You can also describe sed as a filter. Let's have
 	a look at some examples:
 
    	<tscreen><verb>
 	$sed 's/to_be_replaced/replaced/g' /tmp/dummy
 	</verb></tscreen>
 
-   	<P> Sed replaces the string 'to_be_replaced' with the string 'replaced' and 
-	reads from the /tmp/dummy file. The result will be sent to stdout (normally 
-	the console) but you can also add '> capture' to the end of the line above so 
+   	<P> Sed replaces the string 'to_be_replaced' with the string 'replaced' and
+	reads from the /tmp/dummy file. The result will be sent to stdout (normally
+	the console) but you can also add '> capture' to the end of the line above so
 	that sed sends the output to the file 'capture'.
 
 	<tscreen><verb>
    	$sed 12, 18d /tmp/dummy
-	</verb></tscreen>	
+	</verb></tscreen>
 
    	<P> Sed shows all lines except lines 12 to 18. The original file is not altered by this command.
 
@@ -921,7 +922,7 @@ Tables
    <P> <it/while (i != 9) {/
    <P> <it/i = i + 1;/
 	<P> <it/print i/
-   <P> <it/}/	
+   <P> <it/}/
    <P> <it/123456789/
    <P> <it/quit/
 
@@ -952,103 +953,103 @@ Tables
 <sect>
 More Scripts
      <sect1>
-     Applying a command to all files in a directory. 
-     <P> 
+     Applying a command to all files in a directory.
+     <P>
      </sect1>
      <sect1>
      Sample: A very simple backup script (little bit better)
 	   <P>
 	   <tscreen><verb>
-	    #!/bin/bash          
+	    #!/bin/bash
 	    SRCD="/home/"
 	    TGTD="/var/backups/"
 	    OF=home-$(date +%Y%m%d).tgz
 	    tar -cZf $TGTD$OF $SRCD
-	   </verb></tscreen> 
+	   </verb></tscreen>
 	   <P>
      </sect1>
      <sect1>
      File re-namer
           <P>
 	  <tscreen><verb>
-          
+
              #!/bin/sh
              # renna: rename multiple files according to several rules
              # written by felix hudson Jan - 2000
-             
+
              #first check for the various 'modes' that this program has
              #if the first ($1) condition matches then we execute that portion of the
              #program and then exit
-             
+
              # check for the prefix condition
              if [ $1 = p ]; then
-             
+
              #we now get rid of the mode ($1) variable and prefix ($2)
                prefix=$2 ; shift ; shift
-             
+
              # a quick check to see if any files were given
              # if none then its better not to do anything than rename some non-existent
              # files!!
-             
+
                if [$1 = ]; then
                   echo "no files given"
                   exit 0
                fi
-             
+
              # this for loop iterates through all of the files that we gave the program
              # it does one rename per file given
                for file in $*
                  do
                  mv ${file} $prefix$file
                done
-             
+
              #we now exit the program
                exit 0
              fi
-             
+
              # check for a suffix rename
              # the rest of this part is virtually identical to the previous section
              # please see those notes
              if [ $1 = s ]; then
                suffix=$2 ; shift ; shift
-             
+
                 if [$1 = ]; then
                  echo "no files given"
                 exit 0
                 fi
-             
+
               for file in $*
                do
                 mv ${file} $file$suffix
               done
-             
+
               exit 0
              fi
-             
+
              # check for the replacement rename
              if [ $1 = r ]; then
-             
+
                shift
-             
+
              # i included this bit as to not damage any files if the user does not specify
              # anything to be done
              # just a safety measure
-             
+
                if [ $# -lt 3 ] ; then
                  echo "usage: renna r [expression] [replacement] files... "
                  exit 0
                fi
-             
+
              # remove other information
                OLD=$1 ; NEW=$2 ; shift ; shift
-             
+
              # this for loop iterates through all of the files that we give the program
              # it does one rename per file given using the program 'sed'
              # this is a sinple command line program that parses standard input and
              # replaces a set expression with a give string
              # here we pass it the file name ( as standard input) and replace the nessesary
              # text
-             
+
                for file in $*
                do
                  new=`echo ${file} | sed s/${OLD}/${NEW}/g`
@@ -1056,7 +1057,7 @@ More Scripts
                done
              exit 0
              fi
-             
+
              # if we have reached here then nothing proper was passed to the program
              # so we tell the user how to use it
              echo "usage;"
@@ -1064,9 +1065,9 @@ More Scripts
              echo " renna s [suffix] files.."
              echo " renna r [expression] [replacement] files.."
              exit 0
-             
+
              # done!
-             
+
 	  </verb></tscreen>
      </sect1>
      <sect1>
@@ -1080,8 +1081,8 @@ More Scripts
      criteria=$1
      re_match=$2
      replace=$3
-     
-     for i in $( ls *$criteria* ); 
+
+     for i in $( ls *$criteria* );
      do
          src=$i
 	 tgt=$(echo $i | sed -e "s/$re_match/$replace/")
@@ -1094,7 +1095,7 @@ More Scripts
 <sect>
 When something goes wrong (debugging)
      <sect1>
-     Ways Calling BASH 
+     Ways Calling BASH
           <p> A nice thing to do is to add on the first line
 	  <tscreen><verb>
 	  #!/bin/bash -x
@@ -1105,27 +1106,27 @@ When something goes wrong (debugging)
 
 <sect>
 About the document
-     <P> Feel free to make suggestions/corrections, or whatever you think 
+     <P> Feel free to make suggestions/corrections, or whatever you think
      it would be interesting to see in this document. I'll try to update
      it as soon as I can.
      <sect1>
      (no) warranty
           <P> This documents comes with no warranty of any kind.
-	  and all that 
+	  and all that
      </sect1>
      <sect1>
      Translations
-     	<p> Italian: by William Ghelfi (wizzy at tiscalinet.it) 
+     	<p> Italian: by William Ghelfi (wizzy at tiscalinet.it)
      		<htmlurl name="is here" url="http://web.tiscalinet.it/penguin_rules">
-     	<p> French: by Laurent Martelli 
+     	<p> French: by Laurent Martelli
 		<htmlurl name="is missed" url="http://">
-	<p> Korean: Minseok Park 
+	<p> Korean: Minseok Park
 		<htmlurl url="http://kldp.org" name="http://kldp.org">
-	<p> Korean: Chun Hye Jin 
+	<p> Korean: Chun Hye Jin
 		<htmlurl url="" name="unknown">
-	<p> Spanish: unknow 
+	<p> Spanish: unknow
 		<htmlurl url="http://www.insflug.org" name="http://www.insflug.org">
-     <p> I guess there are more translations, but I don't have any info of them, 
+     <p> I guess there are more translations, but I don't have any info of them,
      if you have it, please, mail it to me so I update this section.
      </sect1>
      <sect1>
@@ -1136,10 +1137,10 @@ About the document
         <item> Nathan Hurst for sending a lot of corrections.
 	<item> Jon Abbott for sending comments about evaluating arithmetic expressions.
 	<item> Felix Hudson for writing the <it/renna/ script
-	<item> Kees van den Broek 
+	<item> Kees van den Broek
 		(for sending many corrections, re-writting usefull comands section)
 	<item> Mike (pink) made some suggestions about locating bash and testing files
-	<item> Fiesh make a nice suggestion for the loops section. 
+	<item> Fiesh make a nice suggestion for the loops section.
 	<item> Lion suggested to mention a common error (./hello.sh: Command not found.)
 	<item> Andreas Beck made several corrections and coments.
      </itemize>
@@ -1150,11 +1151,11 @@ About the document
 	<p> Added the section usefull commands re-writen by Kess.
 	<p> More corrections and suggestions incorporated.
 	<p> Samples added on string comparison.
-	<p> v0.8 droped the versioning, I guess the date is enought. 
+	<p> v0.8 droped the versioning, I guess the date is enought.
 	<p> v0.7 More corrections and some old TO-DO sections written.
 	<p> v0.6 Minor corrections.
 	<p> v0.5 Added the redirection section.
-	<p> v0.4 disapperd from its location due to my ex-boss and thid doc found it's new place 
+	<p> v0.4 disapperd from its location due to my ex-boss and thid doc found it's new place
 	at the proper url: www.linuxdoc.org.
 	<p> prior:  I don't rememeber and I didn't use rcs nor cvs :(
 	</sect1>
@@ -1165,8 +1166,8 @@ About the document
 	  <P> Introduction to bash (under BE)
 	      <htmlurl url="http://org.laol.net/lamug/beforever/bashtut.htm"
 		name="http://org.laol.net/lamug/beforever/bashtut.htm">
-          <P> Bourne Shell Programming 
-	      http://207.213.123.70/book/ 
+          <P> Bourne Shell Programming
+	      http://207.213.123.70/book/
      </sect1>
 </sect>
 


### PR DESCRIPTION
This commit contains some minor grammatical/spelling fixes
for the Bash Programming Into HOWTO.

My editor also cleaned up some EOL spaces, if that is annoying I can reconfigure it to stop doing that.