### PR TITLE
remove endterm attribute from <xref/> elements

### DIFF
--- a/LDP/howto/docbook/rpmupgrade/rpmupgrade.xml
+++ b/LDP/howto/docbook/rpmupgrade/rpmupgrade.xml
@@ -511,7 +511,7 @@ CRITICISMS UNTIL I'M FINISHED WRITING IT.</remark>
         and some knowledge of the what each package does. This
         knowledge can be obtained from the package information, of
         course. (See 
-        <xref endterm="rpmtips" linkend="rpmtips" />
+        <xref linkend="rpmtips" />
 
         for how to show the summary information.)</para>
       </listitem>
@@ -1514,8 +1514,7 @@ CRITICISMS UNTIL I'M FINISHED WRITING IT.</remark>
       <filename>/var</filename>
 
       as explained in 
-      <xref endterm="expandrootpartition"
-      linkend="expandrootpartition" />
+      <xref linkend="expandrootpartition" />
 
       and that is why 
       <filename>/extra</filename>
@@ -2177,10 +2176,10 @@ word there is Most.
         crucial that you can't run your Linux system anymore,
         you'll need to run an alternate system. Boot up your spare
         Linux ( 
-        <xref endterm="progtomsrtbt" linkend="progtomsrtbt" />
+        <xref linkend="progtomsrtbt" />
 
         or 
-        <xref endterm="proginstallcd" linkend="proginstallcd" />
+        <xref linkend="proginstallcd" />
 
         ) 
 <!-- FIXME: extra white space -->
@@ -2226,7 +2225,7 @@ word there is Most.
         <application>rpm</application>
 
         are helpful and convenient to have at this point. (See 
-        <xref endterm="othertools" linkend="othertools" />
+        <xref linkend="othertools" />
 
         for some of your options.)</para>
       </listitem>
@@ -3742,7 +3741,7 @@ xreflabel="Upgrade tools from the text, plus others">
   </sect2>
 
   <sect2 id="proginstallcd"
-  xreflabel="You bootable installation CD">
+  xreflabel="Your bootable installation CD">
     <title>Your bootable installation CD</title>
 
     <para>If you have a Linux installation CD that is bootable, you


### PR DESCRIPTION
Several <xref/> elements used the endterm attribute, which takes the entire
content contained in the element as replacement.  Because the endterm was
also, for example, a <section/>, the replaced text was a gigantic (multi-page)
link with the whole section included.  Unintended, I'm sure.