### PR TITLE
Rick Moen is updating the User-Group-HOWTO

### DIFF
--- a/LDP/howto/linuxdoc/User-Group-HOWTO.sgml
+++ b/LDP/howto/linuxdoc/User-Group-HOWTO.sgml
@@ -4,7 +4,7 @@
 
 <title>Linux User Group HOWTO
 <author><url name="Rick Moen" url="mailto:%20rick@linuxmafia.com%20"></author>
-<date>v1.8.4, 2013-07-25
+<date>v1.8.5, 2016-02-25
 
 <abstract>
 The Linux User Group HOWTO is a guide to founding, maintaining, and
@@ -26,6 +26,18 @@ computers, servers, workstations, PDAs, and embedded systems.  It was
 developed on the i386 and now supports a huge range of processors from 
 tiny to colossal:
 
+Note:  The following supported-platforms list is not serious documentation.  
+The point is merely to illustrate the breadth of Linux's reach.  
+If seriously interested in the subject of Linux ports, please see also 
+<url name="Xose Vazquez Perez's Linux ports page" url="http://web.archive.org/web/20070813000855/http://www.itp.uni-hannover.de/ports/linux_ports.html"> and
+<url name="Jerome Pinot's Linux architectures list" url="http://web.archive.org/web/20050308130348/http://ngc891.blogdns.net/kernel/docs/arch.txt"> (static mirrors, as both pages vanished in 2005), if only because 
+hardware support is more complex than just generic CPU functionality, 
+encompassing support for myriad bus variations and other subtle hardware
+issues (especially for 
+<url name="Linux PDA / embedded / microcontroller / router ports" url="http://www.linuxfordevices.com/">).  
+
+
+
 <itemize>
         <item><bf>Diverse <url name="PDA / embedded / microcontroller / router" 
               url="http://www.uclinux.org/ports/"> devices:</bf> 
@@ -41,7 +53,7 @@ url="http://www.freescale.com/files/netcomm/doc/data_sheet/MC68EN302.pdf"></item
                  <item>Intel i960</item>
                  <item>Intel IA32-compatibles (Cyrix MediaGX, STMicroelectronics <url name="STPC" url="http://web.archive.org/web/20070626190436/http://www.stmcu.com/forums-cat-132-6.html">, ZF Micro ZFx86)</item>
                  <item>Matsushita <url name="AM3x" url="http://ecos.sourceware.org/hardware.html#Matsushita%20AM3x"></item>
-                 <item>MIPS-compatibles (Toshiba TMPRxxxx / TXnnnn, NEC <url name="VR" url="http://www.linux-mips.org/wiki/NEC_VR4100"> series, Realtek 8181">)</item>
+                 <item>MIPS-compatibles (Toshiba TMPRxxxx / TXnnnn, NEC <url name="VR" url="http://www.linux-mips.org/wiki/NEC_VR4100"> series, Realtek 8181")</item>
                  <item>Motorola 680x0-based machines (Motorola VMEbus boards, <url name="ISICAD Prisma" url="http://ds.dial.pipex.com/town/way/fr30/"> machines, and Motorola Dragonball &amp; <url name="ColdFire" url="http://www.uclinux.org/ports/coldfire/"> CPUs, and Cisco 2500/3000/4000 series routers)</item>
                  <item>Motorola embedded <url name="PowerPC" url="http://penguinppc.org/embedded/"> (including MPC / PowerQUICC I, II, III families)</item>
                  <item>NEC <url name="V850E" url="http://ecos.sourceware.org/tools/linux-v850-elf.html"></item>
@@ -107,49 +119,38 @@ at all maintained since creation.  On some of the rarer architectures,
 (The 
 <url name="Debian GNU/kFreeBSD" url="http://www.debian.org/ports/kfreebsd-gnu/"> port should also be solid enough to 
 serve as a compromise option, furnishing GNU/Linux userspace code on the
-high performance / high stability FreeBSD kernel, and <url name="NexentaOS" url="http://en.wikipedia.org/wiki/Nexenta_OS">
-provides something similar on the OpenSolaris kernel.)
-
-If seriously interested in the subject of Linux ports, please see also 
-<url name="Xose Vazquez Perez's Linux ports page" 
-url="http://web.archive.org/web/20070813000855/http://www.itp.uni-hannover.de/ports/linux_ports.html"> and
-<url name="Jerome Pinot's Linux architectures list"
-url="http://web.archive.org/web/20050308130348/http://ngc891.blogdns.net/kernel/docs/arch.txt"> (static mirrors, as both pages vanished in 2005), if only because 
-hardware support is more complex than just generic CPU functionality, 
-encompassing support for myriad bus variations and other subtle hardware
-issues (especially for 
-<url name="Linux PDA / embedded / microcontroller / router ports" 
-url="http://www.linuxfordevices.com/">).  
-The above list aims mostly to generally illustrate the breadth of 
-Linux's reach.
+high performance / high stability FreeBSD kernel, and <url name="Dyson" url="https://en.wikipedia.org/wiki/Dyson_(operating_system)"> or another <url name="Illumos distribution" url="https://en.wikipedia.org/wiki/Illumos#Relatives">
+can provide something similar on the OpenSolaris kernel.)
 
 <sect1>Other sources of information
 <p>
-If you want to learn more, the <url url="http://www.tldp.org/"
-name="Linux Documentation Project"> is a good place to start.
+If you want to learn more, the <url name="Linux Documentation Project"
+url="http://www.tldp.org/"> is a good place to start.
 
 For general information about computer user groups, please see the
-<url name="Association of PC Users Groups"
-url="http://www.apcug.net/">.
+<url name="Association of PC Users Groups" url="http://apcug2.org/">.
 
 <sect>What is a GNU/Linux user group?
 <p>
 
 <sect1>What is GNU/Linux?
 <p>
-To fully appreciate LUGs' role in the GNU/Linux movement, it helps to
-understand what makes GNU/Linux unique.
+To fully appreciate LUGs' (Linux User Groups') role in the GNU/Linux 
+movement, it helps to understand what makes GNU/Linux unique.
 
 GNU/Linux as an operating system is powerful -- but GNU/Linux as an
 <it><bf>idea</bf></it> about software development is even more so. GNU/Linux
 is a <bf>free</bf> operating system: It's licensed under the GNU General
-Public Licence. Thus, source code is freely available in perpetuity to
-anyone.  It's maintained by a unstructured group of programmers
-world-wide, under technical direction from Linus Torvalds and other key
-developers. GNU/Linux as a movement has no central structure, bureaucracy,
-or other entity to direct its affairs. While this situation has
-advantages, it poses challenges for allocation of human resources,
-effective advocacy, public relations, user education, and training.
+Public Licence (and other open source / free software licences -- though 
+proprietary application software is sometimes also included in
+particular packagings). Thus, source code is freely available in
+perpetuity to anyone. It's maintained by a unstructured group of
+programmers world-wide, under technical direction from Linus Torvalds
+and other key developers. GNU/Linux as a movement has no central
+structure, bureaucracy, or other entity to direct its affairs. While
+this situation has advantages, it poses challenges for allocation of
+human resources, effective advocacy, public relations, user education,
+and training.
 
 <p>
 (This HOWTO credits the Free Software Foundation's 
@@ -159,6 +160,11 @@ aka open source integrated system.  Thus, it refers to "distributions"
 comprising the GNU operating system atop the Linux kernel as "GNU/Linux".
 Yes, the term is awkward, and FSF's request for credit isn't widely 
 honoured; but the justice of FSF's claim is obvious.)
+
+(This HOWTO's maintainer is also fully aware that the world at large
+will never adopt this usage, justice notwithstanding.  If it seems 
+mannered, please indulge him, and respect the gesture.)
+
 
 <sect1>How is GNU/Linux unique?
 <p>
@@ -171,12 +177,12 @@ However, this loose structure can disorient the new user: Whom
 does she call for support, training, or education? How does she know
 what GNU/Linux is suitable for?
 
-In part, LUGs provide the answers, which is why LUGs are vital to
+In part, LUGs provide the answers, which is why LUGs have been vital to
 the movement: Because your town, village, or metropolis sports no
 Linux Corporation "regional office", the LUG takes on many of the same
 roles a regional office does for a large multi-national corporation.
 
-GNU/Linux is unique in neither having nor being burdened by central
+GNU/Linux is unusual in neither having nor being burdened by central
 structures or bureaucracies to allocate its resources, train its users,
 and support its products. These jobs get done through diverse means: the
 Internet, consultants, VARs, support companies, colleges, and
@@ -191,7 +197,8 @@ Microcomputers arose in large part to satisfy demand for affordable,
 personal access to computing resources from electronics, ham radio, and
 other hobbyist user groups.  Giants like IBM eventually discovered the
 PC to be a good and profitable thing, but initial impetus came from the
-grassroots.
+grassroots, leading to groundbreaking efforts like SHARE (1955-present) 
+and DECUS (1961-2008).
 
 In the USA, user groups have changed -- many for the worse --
 with the times. The financial woes and dissolution of the largest user
@@ -228,6 +235,59 @@ distribution-restricted proprietary software of any sort should be
 heavily discouraged anywhere in LUGs, and declared off-topic for all 
 GNU/Linux user group on-line forums, for legal reasons.)
 
+<sect1>Avoiding Burnout and Decline
+<p>
+Since around 2003, LUGs in developed countries have seen a decline
+similar to that of traditional user groups.  The causes can be debated,
+and might include:
+
+<itemize>
+        <item>GNU/Linux being so successful that it's often perceived as
+infrastructure rather than as something new and interesting.</item>
+        <item>LUGs getting lost in the noise of social media.</item>
+        <item>Early adopters critical to making LUGs function moving
+on to other interests.</item>
+        <item><url name="Meetup.com" url="http://linuxmafia.com/faq/Essays/meetup.html">, with its strong inward-facing focus, sucking
+away available talent and energy, and making LUGs less noticeable.</item>
+        <item>GNU/Linux becoming so much easier to install
+and use that focus has shifted to more-specialised topics better served
+by more-specialised technical communities (DevOps, Bioinformatics,
+cloud computing, embedded computing, and many others).</item>
+        <item>LUG leaders poorly managing a generational transition, 
+leaving nobody ready to take over as they bow out.</item>
+	<item>Greater ubiquity of the Internet generally, and
+specifically reputation-based collaborative sites like StackExchange,
+StackOverflow, Doctype, Codeproject, and Serverfault, not to mention 
+users becoming skilled at Web-searching, making LUGs far less
+pragmatically necessary, and the main action involving SaaS sites having 
+site scale and network effects with which LUGs cannot compete.</item>
+</itemize>
+
+A few time-tested tips for averting LUG flameout:
+
+<itemize>
+        <item>Automation is your friend.  Any task that can be scripted, 
+should be scripted.</item>
+        <item>Check all your LUG's systems, both technical and social,
+for single points of failure (SPoFs).  Keep trying to make sure there are
+fallbacks if anything or anyone fails.  Do backups.  Ensure that nothing
+important can be done by only one person.</item>
+        <item>Beware of your LUG, or any individual in it, committing 
+to carrying out too much work, or with too great frequency.  It's 
+better for a LUG to do less, or have its functions occur less often,
+than risk people wearing out and leaving.</item>
+        <item>Remember that if people aren't having fun, they won't 
+continue for long.  E.g., if your group becomes less technical and 
+more social, don't fret.  It's probbly a healthy thing.</item>
+	<item>Carefully guard your significant assets, such as domain
+ownership, difficult-to-acquire meeting venues, and the names of key
+corporate contacts, and keep them away from problematic people sometimes
+drawn to LUGs.  Even if you, say, wrestle your domain away from someone
+who's suddenly decided to destroy the LUG (which does happen), the
+strife will drive away key people.</item>
+</itemize>
+
+
 <sect1>Summary
 <p>
 For the GNU/Linux movement to grow, among other requirements,
@@ -251,23 +311,22 @@ LUG, your first task should be to find any nearby existing LUGs.
 <it>Your best bet may be to join a LUG already established in your area,
 rather than founding one.</it>
 
-As of 2007, there are LUGs in all 50 US states plus the District of
-Columbia, all of Canada's ten provinces and three territories, all six of 
-Australia's states plus the Australian Capital Territory, in 76 locations 
-in India, and over 100 other countries, including Russia, China, and most 
-of Western and Eastern Europe. 
+As of 2016, there are LUGs in 43 US states, seven of Canada's ten provinces, 
+all six of Australia's states plus the Australian Capital Territory, in 76 
+locations in India, and over 100 other countries, including Russia, China, most 
+of Western and Eastern Europe, and many parts of Africa, South America, Central 
+America, Oceania, and the Caribbean.  (This does not include Linux groups 
+internal to <url name="Meetup.com" url="http://linuxmafia.com/faq/Essays/meetup.html">.)
 
 <itemize>
-        <item><url name="Linux.org List" url="http://www.linux.org/xfa-groups-home/"></item>
-	<item><url name="LibrePlanet Group List" url="http://libreplanet.org/wiki/Group_list"></item>
-	<item><url name="Open Directory: LUGS" url="http://dmoz.org/Computers/Software/Operating_Systems/Linux/User_Groups/"></item>
-	<item><url name="Lea-Linux List" url="http://www.lea-linux.org/documentations/index.php/Annuaire:LUG_%26_assos_nationales"></item>
-	<item><url name="Yahoo Linux &gt; User Groups" url="http://dir.yahoo.com/Computers_and_Internet/Software/Operating_Systems/Unix/Linux/User_Groups/">
-	<item><url name="CLUE: the Canadian Linux Users' Exchange" url="http://www.linux.ca/"></item>
+        <item><url name="Lugslist" url="http://lugslist.com/"></item>
+	<item><url name="DMOZ Linux User Groups" url="http://dmoz.org/Computers/Software/Operating_Systems/Linux/User_Groups/"></item>
+	<item><url name="L&eacute;a-Linux List" url="http://www.lea-linux.org/documentations/index.php/Annuaire:LUG_%26_assos_nationales">  (text is in French)</item>
         <item><url name="UK Linux User Groups" url="http://www.lug.org.uk/"></item>
-	<item><url name="Linux Australia" url="http://www.linux.org.au/"></item>
+	<item><url name="Linux Australia" url="http://linux.org.au/usergroups"></item>
 	<item><url name="LUGs List for India and Asia" url="http://www.wikiwikiweb.de/LugsList"></item>
         <item><url name="I Linux User Group italiani" url="http://lugmap.linux.it/"></item>
+	<item><url name="LibrePlanet Group List" url="http://libreplanet.org/wiki/Group_list"> (lists FSF affiliates only)</item>
 </itemize>
 
 <sect1>Solidarity versus convenience
@@ -422,7 +481,7 @@ offered them a solution -- by charging money.
 
 Seen from this perspective, being conservative about the costs and
 difficulties of GNU/Linux deployments helps make them positively attractive
--- and protects your credibility as a spokesman.  Even better would be
+-- and protects your credibility as a speaker.  Even better would be
 to frame the discussion of costs in terms of the cost of functionality
 (e.g., 1000-seat Internet-capable company e-mail with offline-user
 capability and webmail) as opposed to listing software as a retail-style
@@ -465,7 +524,7 @@ for example, LUGs have taken GNU/Linux into local schools, small businesses,
 community and social organisations, and other non-corporate
 environments. This accomplishes the goal of advocacy and also
 educates the general public.  As more such organisations seek Internet
-presence,  provide their personnel dial-in access, or other
+presence, provide their personnel dial-in access, or other
 GNU/Linux-relevant functions, LUGs gain opportunities for community
 participation, through awareness and education efforts -- extending to
 the community the same generous spirit characteristic of GNU/Linux and the
@@ -478,7 +537,7 @@ GNU/Linux is a natural fit for these organisations, because deployments
 don't commit them to expensive licence, upgrade, or maintenance fees.
 Being technically elegant and economical, it also runs very well on
 cast-off corporate hardware that non-profit organisations are only too
-happy to use: The unused Pentium II in the closet can do <bf>real
+happy to use: The unused Pentium III in the closet can do <bf>real
 work</bf>, if someone installs GNU/Linux on it.
 
 In addition, education assists other LUG goals over time, in
@@ -495,19 +554,18 @@ allied projects such as the Apache Web server, X.org, Freedesktop.org,
 TeX, LaTeX, etc.  -- is key to this dynamic: Education turns new users into
 experienced ones.
 
-Finally, GNU/Linux is a self-documenting operating environment: In other words,
-writing and publicising our community's documentation is up to us.
-Therefore, make sure LUG members know of the <url name="Linux
+Finally, GNU/Linux is a self-documenting operating environment: In other
+words, writing and publicising our community's documentation is up to
+us.  Therefore, make sure LUG members know of the <url name="Linux
 Documentation Project" url="http://www.tldp.org/"> and its worldwide
 mirrors.  Consider operating an LDP mirror site.  Also, make sure to
 publicise -- through <tt>comp.os.linux.announce</tt>, the LDP, and other
-pertinent sources of information -- any relevant documentation
-the LUG develops: technical presentations, tutorials, local FAQs, etc.
-LUGs' documentation often fails to benefit the worldwide 
-community for no better reason than not notifying the outside world.
-Don't let that happen: It is highly probable that if someone at one LUG
-had a question or problem with something, then others elsewhere
-will have it, too.
+pertinent sources of information -- any relevant documentation the LUG
+develops: technical presentations, tutorials, local FAQs, etc.  LUGs'
+documentation often fails to benefit the worldwide community for no
+better reason than not notifying the outside world.  Don't let that
+happen: It is highly probable that if someone at one LUG had a question
+or problem with something, then others elsewhere will have it, too.
 
 <sect1>GNU/Linux support
 <p>
@@ -529,22 +587,31 @@ LUGs have the opportunity to support:
 <p>
 New users' most frequent complaint, once they have GNU/Linux
 installed, is the steep learning curve characteristic of all modern 
-Unixes. With that learning curve, however, comes the power and 
-flexibility of a real operating system. A LUG is often the a new 
-user's main resource to flatten the learning curve.
+Unixes. (That sentence was true in 1997 when this HOWTO's first
+maintainer wrote it, but happily not much any more.)  With that learning
+curve, however, comes the power and flexibility of a real operating
+system. A LUG is often the a new user's main resource to flatten the
+learning curve.
 
 During GNU/Linux's first decade, it gained some first-class journalistic 
-resources, which should not be neglected:  The main monthly magazines
-of longest standing are <it><url name="Linux Journal"
-url="http://www.linuxjournal.com/"></it> and <it><url name="Linux Gazette"
-url="http://linuxgazette.net/"></it>.  More recently, 
+resources, which should not be neglected:  The main (surviving) monthly 
+magazine of longest standing is <it><url name="Linux Journal"
+url="http://www.linuxjournal.com/"></it> (USA).
+More recently, 
 they've been joined by 
-<it><url name="LinuxFocus" url="http://www.linuxfocus.org/"></it> and the
-<it><url name="New LinuxFocus" url="http://new.linuxfocus.org/cms/"></it> (on-line),
-<it><url name="Linux Format" url="http://www.linuxformat.com"></it>,
-<it><url name="LinuxUser and Developer" url="http://www.linuxuser.co.uk/"></it>,
-<it><url name="Linux Magazine" url="http://www.linux-magazine.com/"></it>, and
-<it><url name="LINUX For You" url="http://www.linuxforu.com/"></it>.
+<it><url name="Linux Format" url="http://www.linuxformat.com"></it> (UK),
+<it><url name="LinuxUser and Developer" url="http://www.linuxuser.co.uk/"></it> (UK),
+<it><url name="Linux Magazine" url="http://www.linux-magazine.com/"></it> (German publishing firm; publishes in English, German, Polish, Brazilian Portuguese, and Spanish; North American edition is named Linux Pro Magazine),
+<it><url name="Open Source For You"
+url="http://opensourceforu.efytimes.com/"></it> (India; formerly <it>LINUX
+For You)</it>,
+<it><url name="Full Circle" url="http://fullcirclemagazine.org/"></it>
+(international; covers Ubuntu family distributions), 
+<it><url name="Linux Voice" url="http://linuxvoice.com/"></it> (UK), 
+<it><url name="easyLinux" url="http://www.easylinux.de/"></it> (German),
+<it><url name="LinuxUser" url="https://www.linux-user.de/"</it> (German), and
+<it><url name="Ubuntu User" url="http://www.ubuntu-user.com/"></it> (German
+publishing firm; in English).
 
 Standout on-line magazines and news sites with weekly or better publication 
 cycles include <it><url name="Linux Weekly News" url="http://lwn.net/"></it>, 
@@ -556,18 +623,18 @@ All of these resources have eased LUGs' job of spreading essential
 news and information --  about bug fixes, security problems, patches, 
 new kernels, etc., but new users must still be made aware of
 them, and taught that the newest kernels are always
-available from <url name="ftp.kernel.org" url="ftp://ftp.kernel.org">,
+available from <url name="kernel.org" url="https://www.kernel.org/">,
 that the <url name="Linux Documentation Project" url="http://www.tldp.org/">
-has newer versions of Linux HOWTOs than do CD-based GNU/Linux distributions, 
-and so on.
+has newer versions of Linux HOWTOs than do DVD/CD-based GNU/Linux
+distributions, and so on.
 
-Intermediate and advanced users
-also benefit from proliferation of timely and useful tips, facts,
-and secrets. Because of the GNU/Linux world's manifold aspects, even
-advanced users often learn new tricks or techniques simply by
-participating in a LUG. Sometimes, they learn of software packages
-they didn't know existed; sometimes, they just remember arcane
-<tt>vi</tt> command sequences they've not used since college.
+Intermediate and advanced users also benefit from proliferation of
+timely and useful tips, facts, and secrets. Because of the GNU/Linux
+world's manifold aspects, even advanced users often learn new tricks or
+techniques simply by participating in a LUG. Sometimes, they learn of
+software packages they didn't know existed; sometimes, they just
+remember arcane <tt>vi</tt> command sequences they've not used since
+college.
 
 <sect2>Consultants
 <p>
@@ -643,7 +710,7 @@ Telltale signs that a questioner may need to be transitioned to consulting-based
 
 In general, LUG members are especially delighted to help, on a volunteer
 basis, members who seem likely to participate in the "gift
-culture" by picking up its body of  lore and, in turn, perpetuating it
+culture" by picking up its body of lore and, in turn, perpetuating it
 by teaching others in their turn.  Certainly, there's nothing wrong with
 having other priorities and values, but such folk may in some cases be
 best referred to paid assistance, as a better fit for their needs.
@@ -658,7 +725,8 @@ advised to be aware, if not wary, of this distinction.
 
 Please see Joshua Drake's <url name="Linux Consultants Guide"
 url="http://www.commandprompt.com/community/consultants/guide/"> for an
-international list of GNU/Linux consultants.
+international list of GNU/Linux consultants.  (Note:  As of 2016,
+Drake's list was last updated in 2006.)
 
 <sect2>Businesses, non-profit organisations, and schools
 <p>
@@ -675,7 +743,7 @@ a part of their computing operations differs little from the help LUGs
 give individuals trying GNU/Linux at home. For example, compiling the Linux
 kernel doesn't really differ. Supporting businesses, however, may
 require supporting proprietary software -- e.g., the Oracle, Sybase,
-and DB2 databases (or VMware, Win4Lin, and such things).   
+and DB2 databases (or VMware, CrossOver Linux, and such things).   
 Some LUG expertise in these areas may help businesses make the leap
 into GNU/Linux deployments.
 
@@ -742,7 +810,7 @@ development of software working with GNU/Linux:
 <item><url url="http://www.linuxfoundation.org/about" name="The Linux Foundation">
 <item><url url="http://www.debian.org/donations.html" name="Debian / Software In the Public Interest">
 <item><url url="https://my.fsf.org/associate/support_freedom" name="Free Software Foundation"> 
-<item><url url="http://www.kde.org/community/donations/" name="KDE Project">
+<item><url url="http://www.kde.org/community/donations/" name="KDE Project (KDE e.V.)">
 <item><url url="http://www.gnome.org/friends/" name="GNOME Foundation">
 </itemize>
 
@@ -822,13 +890,6 @@ other school officials. OSEF installs and supports school computer labs,
 and has developed a "K12 Box" as a compact Plug and Play workstation 
 computer for student computer labs.
 
-<item> <url url="http://www.osafoundation.org/donations.htm" name="Open 
-Source Applications Foundation"> 
-
-<p>OSAF is Mitch Kapor's non-profit foundation to create and popularise
-open-source application software of uncompromising quality, starting
-with its pioneering personal information manager, Chandler.
-  
 </itemize>
 
 (Please note that suggested additions to the above list of GNU/Linux-relevant 
@@ -866,11 +927,12 @@ have a LUG that didn't engage in the other goals, there may be
 LUGs for which socialising isn't a factor.
 
 It seems, however, that whenever two or three GNU/Linux users get together,
-fun, hijinks, and, often, beer follow. Linus Tovalds has
+fun, hijinks, and, often, beer follow. Linus Torvalds has
 always had one enduring goal for Linux: to have more fun. For hackers,
 kernel developers, and GNU/Linux users, there's nothing quite like
 downloading a new kernel, recompiling an old one, fooling with a
-window manager, or hacking some code. GNU/Linux's sheer fun keeps many
+window manager or desktop environment, hacking some code, or experimenting
+with an innovative embedded Linux computer. GNU/Linux's sheer fun keeps many
 LUGs together, and leads LUGs naturally to socialising.
 
 By "socialising", here I mean primarily sharing experiences, forming
@@ -884,11 +946,11 @@ hackers. In other words, acculturation turns you from "one of them" to
 
 It is important that new users come to learn GNU/Linux culture,
 concepts, traditions, and vocabulary.  GNU/Linux acculturation, unlike "real
-world" acculturation, can occur on mailing lists and Usenet, although
-the latter's efficacy is challenged by poorly acculturated users and by
-spam. LUGs are often much more efficient at this task than are mailing 
-lists or newsgroups, precisely because of the former's greater interactivity 
-and personal focus.
+world" acculturation, can occur on mailing lists, Web forums, and
+Usenet, although the latter's efficacy is challenged by poorly
+acculturated users and by spam. LUGs are often much more efficient at
+this task than are mailing lists, Web forums, or newsgroups, precisely
+because of LUGs' greater interactivity and personal focus.
 
 <sect>LUG activities
 <p>
@@ -937,9 +999,9 @@ pages, if not whole Web sites. In fact, I'm not sure how else to find a
 LUG, but to check the Web.  
 
 It makes sense, then, for a LUG to make use of whatever Internet
-technologies they can: Web sites, mailing lists, wikis, ftp, e-mail, Web
+technologies they can: Web sites, mailing lists, wikis, e-mail, Web
 discussion forums, netnews, etc. As the world of commerce is
-discovering, the 'Net is an effective way to advertise, inform, educate,
+discovering, the Net is an effective way to advertise, inform, educate,
 and even sell. The other reason LUGs make extensive use of Internet
 technology is that the very essence of GNU/Linux is to <it>provide</it>
 a stable and rich platform to deploy these technologies. So,
@@ -966,7 +1028,7 @@ spends considerable time discussing Web issues.  Quoting it (in outline form):
 	<item>You need to get on the main lists of LUGs, and keep your entries accurate.
 	<item>You must have login access to maintain your Web pages, as needed.
 	<item>Design your Web page to be forgiving of deferred maintenance.
-	<item>Always include the day of the week, when you cite event dates. Always check that day of the week, first, using gcal.
+	<item>Always include the day of the week, when you cite event dates. Always check that day of the week, first, using cal.
 	<item>Place time-sensitive and key information prominently near the top of your main Web page.
 	<item>Include maps and directions to your events.
 	<item>Emphasise on your main page that your meeting will be free of charge and open to the public (if it is).
@@ -986,7 +1048,7 @@ Some LUGs using the Internet effectively:
 
 <itemize>
 
-	<item><url name="Atlanta Linux Enthusiasts" url="http://www.ale.org/"></item>
+	<item><url name="Atlanta Linux Enthusiasts" url="http://ale.org/"></item>
 
 	<item><url name="Boston Linux and Unix" url="http://www.blu.org/"></item>
 
@@ -1019,10 +1081,6 @@ Some LUGs using the Internet effectively:
 	<item><url name="Tokyo Linux Users Group" url="http://www.tlug.jp/"></item>
 
 	<item><url name="Turkish Linux User Group" url="http://www.linux.org.tr/"></item>
-
-	<item><url name="Victoria Linux User Group" url="http://www.vlug.org/"></item>
-
-	<item><url name="Volgograd Linux User Group" url="http://volgograd.lug.ru/"></item>
 
 </itemize>
 
@@ -1087,7 +1145,7 @@ One of the long-time ones remains active:
 	<item>Schedule a mixture of advanced and basic, formal and informal, presentations.</item>
 	<item>Support the software development efforts of your members.</item>
 	<item>Find way to raise money without dues: for instance, selling GNU/Linux merchandise to your members and to others.</item>
-	<item>Consider securing formal legal standing for the group, such as incorporation or tax-exempt status.</item>
+	<item>(Very optional:)  Consider securing formal legal standing for the group, such as incorporation or tax-exempt status.</item>
 	<item>Find out if your meeting place is restricting growth of the LUG.</item>
 	<item>Meet in conjunction with swap meets, computer shows, or other community events where computer users -- i.e., potential GNU/Linux users -- are likely to gather.</item>
 	<item>Elect formal leadership for the LUG as soon as practical: Some helpful officers might include President, Treasurer, Secretary, Meeting Host (general announcements, speaker introductions, opening and closing remarks, etc.), Publicity Coordinator (handles Usenet and e-mail postings, local publicity), and Program Coordinator (organises and schedules speakers at LUG meetings).</item>
@@ -1124,13 +1182,19 @@ liability and helps the group carry insurance.  It aids fundraising.
 It avoids claims for tax on group income.
 
 <it>Con:</it> Liability shouldn't be a problem for modestly careful
-people. (You're not doing skydiving, after all.)  Fundraising isn't needed
-for a group whose activities needn't involve significant expenses.
-(Dead-tree newsletters are so 1980.)  Not needing a treasury, you avoid
-needing to argue over it, file reports about it, or fear it being taxed
-away. Meeting space can usually be gotten for free at ISPs, colleges,
-pizza parlours, brewpubs, coffeehouses, computer-training firms,
-GNU/Linux-oriented companies, or other friendly institutions, and can
+people.  (You're not doing skydiving, after all.)  Also, even
+incorporated technical groups seldom carry liability insurance, and that
+insurance is typically so narrow in coverage that almost nothing a LUG
+does would be covered, a corporate liability shield is little use for
+such needs either (limiting only the group's potential losses to the
+equity stake of the owners, but conferring no immunity to anyone for 
+deeds that person carries out).  Fundraising isn't needed for a group whose
+activities needn't involve significant expenses.  (Dead-tree newsletters
+are so 1980.)  Not needing a treasury, you avoid needing to argue over
+it, file reports about it, or fear it being taxed away. Meeting space
+can usually be gotten for free at ISPs, colleges, pizza parlours,
+brewpubs, coffeehouses, computer-training firms, GNU/Linux-oriented
+companies, hackerspaces, or other friendly institutions, and can
 therefore be free of charge to the public.  No revenues and no expenses
 means less need for organisation and concomitant hassles.
 
@@ -1301,7 +1365,7 @@ SUSE.  Keep in mind that all three of these companies have made and
 continue to make significant contributions to free / open-source software.
 
 (HOWTO maintainer's note:  The above was a 1998 note, from before
-Caldera exited the GNU/Linux business, renamed itself to The SCO Group,
+Caldera Systems exited the GNU/Linux business, renamed itself to The SCO Group,
 Inc., and launched a major copyright / contract / patent / trade-secret
 lawsuit and PR campaign against GNU/Linux users.  My, those times do change.
 Still, we're grateful to the Caldera Systems that <em> was </em>, for
@@ -1482,11 +1546,11 @@ Have fun!
 <sect1>Terms of use
 <p>
 
-Copyright (C) 2003-2013, Rick Moen.  Copyright (C) 1997-1998 by Kendall Grant 
+Copyright (C) 2003-2016, Rick Moen.  Copyright (C) 1997-1998 by Kendall Grant 
 Clark. This document may be distributed under the terms set forth 
-in the Creative Commons Attribution-ShareAlike 3.0 licence at <url
-name="http://creativecommons.org/licenses/by-sa/3.0/"
-url="http://creativecommons.org/licenses/by-sa/3.0/">, or, at your
+in the Creative Commons Attribution-ShareAlike 4.0 International licence at <url
+name="http://creativecommons.org/licenses/by-sa/4.0/"
+url="http://creativecommons.org/licenses/by-sa/4.0/">, or, at your
 option, any later version.
 
 <sect1>New versions
@@ -1581,9 +1645,39 @@ incorporate improvements.  Re-sorted country coverage into alphabetical
 order (a small gesture to further reduce US-centrism).</item>
         <item>1.8.0:  Corrected typos.  Improved some markup.  Expanded "Common Misconceptions Debunked" section to address recently popular errors about USA Volunteer Protection Act of 1997, civil liability, and IRS 501(c)(3) tax-exempt status.  Linked directly to the Act and an analysis page.  Furnished links for <it>Non-Lawyers' Non-Profit Corporation Kit</it>, for <it>DistroWatch Weekly</it>, and for the Raymond quotation.</item>
 	<item>1.8.1:  Banished more typos.  (I blame society.)</item>
-        <item>1.8.2:  Added more CPU ports.  APCUG changed Web sites.  Linux India's LUG list, lugww.counter.li.org, Red Hat Army of Friends, LUG Webring, O'Reilly LinuxGroups, and LINUX For You Magazine (of India) LUG List vanished.  IDG moved the Raymond article (again).  LinuxFocus was revived via a CMS.  NewsForge was shut down by The Company Formerly Known as VA Linux.  Linux International Development Grant Fund program vanished.  Project Gutenberg moved to its own domain.  Colorado Linux Users and Enthusiasts moved.  Added mention of IRS e-Postcard for 501(c) non-profits.  Added Linux Users Group - Delhi.  Added New Zealand Linux Resource.  Added Project Runeberg.</item>
-        <item>1.8.3:  Replacement ARM Linux Web site.  New URLs for many embedded and other systems.  SoftBlaze renamed to PetaLinux.a  LUGs WorldWide Project, Linux Online -- User Groups, LinuxHQ User Groups, and New Zealand Linux Resource vanished.  Free Software Foundation GNU Users Groups got moved/renamed to LibrePlanet Group List.  New URLs for LinuxFormat and LinuxCounter.  PingoS e.V. vanished (though its SelfLinux project for hypertext tutorials in the German language persists).  Linux User Group of Singapore, St. Petersburg Linux User Group, and Svenska Linuxforeningen folded.</item>
+        <item>1.8.2:  Added more CPU ports.  APCUG changed Web sites.  Linux India's LUG list, lugww.counter.li.org (formerly Woven Goods's Linux Worldwide LUG list), Red Hat Army of Friends, LUG Webring, O'Reilly LinuxGroups, and LINUX For You Magazine (of India) LUG List vanished.  IDG moved the Raymond article (again).  LinuxFocus was revived via a CMS.  NewsForge was shut down by The Company Formerly Known as VA Linux.  Linux International Development Grant Fund program vanished.  Project Gutenberg moved to its own domain.  Colorado Linux Users and Enthusiasts moved.  Added mention of IRS e-Postcard for 501(c) non-profits.  Added Linux Users Group - Delhi.  Added New Zealand Linux Resource.  Added Project Runeberg.</item>
+        <item>1.8.3:  Replacement ARM Linux Web site.  New URLs for many embedded and other systems.  SoftBlaze renamed to PetaLinux.  LUGs WorldWide Project, Linux Online -- User Groups, LinuxHQ User Groups, and New Zealand Linux Resource vanished.  Free Software Foundation GNU Users Groups got moved/renamed to LibrePlanet Group List.  New URLs for LinuxFormat and LinuxCounter.  PingoS e.V. vanished (though its SelfLinux project for hypertext tutorials in the German language persists).  Linux User Group of Singapore, St. Petersburg Linux User Group, and Svenska Linuxforeningen folded.</item>
         <Item>1.8.4:  Linux.org (without its former Linux Online branding) has been rebuilt and offers a new LUG directory.</item>
+        <Item>1.8.5:  Replaced defunct NexentaOS with Dyson and other
+IllumOS distributions.  Recorded new URL for APCUG.  Rewrote introduction
+to list of supported hardware platforms to stress that this part isn't
+serious documentation, but just intended to illustrate the breadth of
+Linux's reach.  Corrected slightly incorrect statement about licensing of
+Linux-based OSes.  Added new section Avoiding Burnout and Decline.
+Added hackerspaces to list of possible metting venues.  Added Lugslist, which
+heroically rose in 2015 to explicitly compensate for collapse of the
+much-missed lugww.counter.li.org and GLUE LUG lists.  Removed linux.org
+LUG list, which Michael McLagen's Linux Online, Inc. deleted without notice.
+Removed Yahoo Linux &gt; User Groups, vanished along with all the rest of
+dir.yahoo.com.  Removed CLUE: the Canadian Linux Users' Exchange at 
+www.linux.ca, which is down for rebuild but is promised to be back Q1
+2016.  Corrected URL for Linux Australia's LUG list.  Removed <it>Linux
+Gazette</it>, folded in 2011.  Removed <it>Linux Focus</it>, dormant
+since 2010.  Updated name and Web site of <it>LINUX for You</it>
+magazine, which has now become <it>OpenSource ForYou</it>.
+Added magazines <it>Full Circle</it>, <it>Linux Voice</it>,
+<it>easyLinux</it>, <it>LinuxUser</it>, and <it>Ubuntu User</it>.
+Clarified where each magazine originates and detail national versions of
+LinuxMagazine.  Replaced reference to Win4Lin with one to CrossOver
+Linux.  Added caution that Linux Consultants Guide is a decade out of
+date.  Removed Open Source Applications Foundation, which seems to have
+died shortly Mitch Kapor left it in 2008.  Added further clarification 
+about limited benefits of incorporation and insurance.  Annotated LibrePlanet 
+list as being FSF affiliates only.  Updated claim about how many LUGs 
+exist worldwide.  Updated version of CC BY-SA licence applicable to this 
+HOWTO from 3.0 to 4.0.
+</item>
+
 </itemize>
 
 
@@ -1614,6 +1708,7 @@ suggestions:
 	<item>Martin Karlsson</item>
 	<item>Hugo van der Kooij</item>
 	<item>Rohit Kumar</item>
+        <item>David Lawyer</item>
 	<item>Charles Lindahl</item>
 	<item>Don Marti</item>
 	<item>Vincenzo Virgilio</item>
@@ -1621,4 +1716,3 @@ suggestions:
 
 
 </article>
-


### PR DESCRIPTION
From: Rick Moen <rick@linuxmafia.com>
To: discuss@en.tldp.org
Subject: Linux User Group HOWTO v. 1.8.5 ready
Date: Thu, 25 Feb 2016 04:30:58

Good folks, I have a major revamp of HOWTO ready for the submission
process.

http://linuxmafia.com/lug/User-Group-HOWTO.sgml

This is Linuxdoc SGML, selected by original author Kendall Grant Clark
back in 1997.  I've verified clean parsing of this revision.
HTML output here:  http://linuxmafia.com/lug/User-Group-HOWTO.html

Licence has been modified slightly on this release from the prior
CC BY-SA 3.0, to CC BY-SA 4.0 (current revision).  CC BY-SA is listed as
an accepted licence on http://wiki.tldp.org/LdpWikiDefaultLicence ,
and I doubt the revamped licence text would create any problme.  (If
LDP has a problem with 4.0, I will back-rev that.)

I hope someone will do me the courtesy of picking up the SGML file and
feeding it into GitHub.  Please advise.  Thank you!

--
Cheers,                  QA engineer walks into a bar.  Orders a beer.
Rick Moen                Orders 0 beers.  Orders 999999999 beers.  Orders
rick@linuxmafia.com      a lizard.  Orders -1 beers.  Orders a sfdeljknesv.
McQ! (4x80)              -- @sempf, https://www.sempf.net/post/On-Testing1.aspx