### PR TITLE
reverting my earlier changes to DocBook 5.0 Assembly-HOWTO, then making minor corrections

### DIFF
--- a/LDP/howto/docbook/Assembly-HOWTO.xml
+++ b/LDP/howto/docbook/Assembly-HOWTO.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
- "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
+<!DOCTYPE book [
 <!ENTITY version "0.7">
 ]>
 
 <!-- $id:$ -->
 
-<book>
-<?dbhtml filename="Assembly-HOWTO.html"?>
+<book xmlns="http://docbook.org/ns/docbook" version="5.0" 
+      xmlns:xlink="http://www.w3.org/1999/xlink"
+      xml:lang="en">
+<!-- <?dbhtml filename="Assembly-HOWTO.html"?> -->
 
-<bookinfo><title>Linux Assembly HOWTO</title>
+<info><title>Linux Assembly HOWTO</title>
 
 <authorgroup>
 <author>
 <personname>
-<anchor xml:id="lnoor"/>
-<firstname>Leo</firstname>
+<firstname><anchor xml:id="lnoor"/>Leo</firstname>
 <surname>Noordergraaf</surname>
 </personname>
 <affiliation>
@@ -30,8 +30,7 @@
 
 <author>
 <personname>
-<anchor xml:id="konst"/>
-<firstname>Konstantin</firstname>
+<firstname><anchor xml:id="konst"/>Konstantin</firstname>
 <surname>Boldyshev</surname>
 </personname>
 <affiliation>
@@ -46,8 +45,7 @@
 
 <author>
 <personname>
-<anchor xml:id="fare"/>
-<firstname>Francois-Rene</firstname>
+<firstname><anchor xml:id="fare"/>Francois-Rene</firstname>
 <surname>Rideau</surname>
 </personname>
 <affiliation>
@@ -132,7 +130,7 @@ platforms.
 <keyword>metaprogramming</keyword>
 <keyword>preprocessor</keyword>
 </keywordset>
-</bookinfo>
+</info>
 
 <chapter xml:id="s-intro" xreflabel="Introduction">
 <?dbhtml filename="introduction.html"?>

--- a/LDP/howto/docbook/Assembly-HOWTO.xml
+++ b/LDP/howto/docbook/Assembly-HOWTO.xml
@@ -7,7 +7,7 @@
 <!-- $id:$ -->
 
 <book>
-<!-- <?dbhtml filename="Assembly-HOWTO.html"?> -->
+<?dbhtml filename="Assembly-HOWTO.html"?>
 
 <bookinfo><title>Linux Assembly HOWTO</title>
 
@@ -20,7 +20,7 @@
 </personname>
 <affiliation>
 <orgname>
-<ulink url="http://asm.sourceforge.net">Linux Assembly</ulink>
+<link xlink:href="http://asm.sourceforge.net">Linux Assembly</link>
 </orgname>
 <address>
 <email>lnoor@users.sourceforge.net</email>
@@ -36,7 +36,7 @@
 </personname>
 <affiliation>
 <orgname>
-<ulink url="http://asm.sourceforge.net">Linux Assembly</ulink>
+<link xlink:href="http://asm.sourceforge.net">Linux Assembly</link>
 </orgname>
 <address>
 <email>konst@users.sourceforge.net</email>
@@ -52,7 +52,7 @@
 </personname>
 <affiliation>
 <orgname>
-<ulink url="http://tunes.org">Tunes project</ulink>
+<link xlink:href="http://tunes.org">Tunes project</link>
 </orgname>
 <address>
 <email>fare@tunes.org</email>
@@ -149,16 +149,16 @@ read all this assembly-unrelated crap.
 <title>Legal Blurb</title>
 <para>
 Permission is granted to copy, distribute and/or modify this document under the
-terms of the GNU <ulink url="http://www.gnu.org/copyleft/fdl.html">Free
-Documentation License</ulink> Version 1.1; with no Invariant Sections, with no
+terms of the GNU <link xlink:href="http://www.gnu.org/copyleft/fdl.html">Free
+Documentation License</link> Version 1.1; with no Invariant Sections, with no
 Front-Cover Texts, and no Back-Cover texts. A copy of the license is included
 in the <xref linkend="a-gfdl"/> appendix.
 </para>
 
 <para>
 The most recent official version of this document is available from the
-<ulink url="http://asm.sourceforge.net/howto.html">Linux Assembly</ulink>
-and <ulink url="http://tldp.org/docs.html">LDP</ulink> sites. If you are
+<link xlink:href="http://asm.sourceforge.net/howto.html">Linux Assembly</link>
+and <link xlink:href="http://tldp.org/docs.html">LDP</link> sites. If you are
 reading a few-months-old copy, consider checking the above URLs for a new
 version.
 </para>
@@ -186,15 +186,15 @@ issue), we are focusing on development of such kind of software.
 </para>
 
 <para>
-If you don't know what <ulink url="http://www.gnu.org/philosophy/">
-<emphasis>free software</emphasis></ulink> is, please do read
+If you don't know what <link xlink:href="http://www.gnu.org/philosophy/">
+<emphasis>free software</emphasis></link> is, please do read
 <emphasis>carefully</emphasis> the GNU
-<ulink url="http://www.gnu.org/copyleft/gpl.html">
-General Public License</ulink> (<acronym>GPL</acronym> or
+<link xlink:href="http://www.gnu.org/copyleft/gpl.html">
+General Public License</link> (<acronym>GPL</acronym> or
 <acronym>copyleft</acronym>), which is used in a lot of free software, and is
 the model for most of their licenses. It generally comes in a file named
 <filename>COPYING</filename> (or <filename>COPYING.LIB</filename>). Literature
-from the <ulink url="http://www.fsf.org">Free Software Foundation</ulink>
+from the <link xlink:href="http://www.fsf.org">Free Software Foundation</link>
 (<acronym>FSF</acronym>) might help you too. Particularly, the interesting
 feature of free software is that it comes with source code which you can
 consult and correct, or sometimes even borrow from. Read your particular
@@ -229,11 +229,11 @@ version 0.5).
 <title>Translations</title>
 <para>
 Korean translation of this HOWTO is avalilable at
-<ulink url="http://kldp.org/HOWTO/html/Assembly-HOWTO/">
-http://kldp.org/HOWTO/html/Assembly-HOWTO/</ulink>.
+<link xlink:href="http://kldp.org/HOWTO/html/Assembly-HOWTO/">
+http://kldp.org/HOWTO/html/Assembly-HOWTO/</link>.
 Turkish translation of this HOWTO is available at
-<ulink url="http://belgeler.org/howto/assembly-howto.html">
-http://belgeler.org/howto/assembly-howto.html</ulink>.
+<link xlink:href="http://belgeler.org/howto/assembly-howto.html">
+http://belgeler.org/howto/assembly-howto.html</link>.
 </para>
 </simplesect>
 </chapter>
@@ -405,7 +405,7 @@ good);
 <listitem>
 <para>
 And in any case, as moderator John Levine says on
-<ulink url="news:comp.compilers">comp.compilers</ulink>,
+<link xlink:href="news:comp.compilers">comp.compilers</link>,
 </para>
 
 <literallayout>
@@ -491,7 +491,7 @@ written in assembly for speed up.
 <section>
 <title>General procedure to achieve efficient code</title>
 <para>
-As Charles Fiterman says on <ulink url="news:comp.compilers">comp.compilers</ulink>
+As Charles Fiterman says on <link xlink:href="news:comp.compilers">comp.compilers</link>
 about human vs computer-generated assembly code:
 </para>
 
@@ -689,19 +689,19 @@ available platforms, notably Linux, *BSD, VSTa, OS/2, *DOS, Win*, etc.
 <section><title>Where to find GCC</title>
 
 <para>
-GCC home page is <ulink url="http://gcc.gnu.org">http://gcc.gnu.org</ulink>.
+GCC home page is <link xlink:href="http://gcc.gnu.org">http://gcc.gnu.org</link>.
 </para>
 
 <para>
 <anchor xml:id="p-djgpp"/>
 DOS port of GCC is called
-<ulink url="http://www.delorie.com/djgpp/">DJGPP</ulink>.
+<link xlink:href="http://www.delorie.com/djgpp/">DJGPP</link>.
 </para>
 
 <para>
 There are two Win32 GCC ports:
-<ulink url="http://www.cygwin.com">cygwin</ulink> and
-<ulink url="http://www.mingw.org">mingw</ulink> 
+<link xlink:href="http://www.cygwin.com">cygwin</link> and
+<link xlink:href="http://www.mingw.org">mingw</link> 
 </para>
 
 <para>
@@ -709,8 +709,8 @@ There is also an OS/2 port of GCC called EMX;
 it works under DOS too,
 and includes lots of unix-emulation library routines.
 Look around the following site:
-<ulink url="ftp://ftp.leo.org/pub/comp/os/os2/leo/gnu/emx+gcc/">
-ftp://ftp.leo.org/pub/comp/os/os2/leo/gnu/emx+gcc/</ulink>.
+<link xlink:href="ftp://ftp.leo.org/pub/comp/os/os2/leo/gnu/emx+gcc/">
+ftp://ftp.leo.org/pub/comp/os/os2/leo/gnu/emx+gcc/</link>.
 </para>
 </section>
 
@@ -752,8 +752,8 @@ The DJGPP Games resource (not only for game hackers) had page specifically
 about assembly, but it's down. Its data have nonetheless been recovered on the
 <link linkend="p-djgpp">DJGPP site</link>, that contains a mine of other
 useful information:
-<ulink url="http://www.delorie.com/djgpp/doc/brennan/">
-http://www.delorie.com/djgpp/doc/brennan/</ulink>.
+<link xlink:href="http://www.delorie.com/djgpp/doc/brennan/">
+http://www.delorie.com/djgpp/doc/brennan/</link>.
 </para>
 
 <para>
@@ -826,7 +826,7 @@ obvious stupid errors.
 You can add some CPU-specific <option>-m486</option> or such flag so that GCC
 will produce code that is more adapted to your precise CPU. Note that modern
 GCC has <option>-mpentium</option> and such flags (and
-<ulink url="http://goof.com/pcg/">PGCC</ulink> has even more), whereas
+<link xlink:href="http://goof.com/pcg/">PGCC</link> has even more), whereas
 GCC 2.7.x and older versions do not. A good choice of CPU-specific flags should
 be in the Linux kernel. Check the TeXinfo documentation of your current GCC
 installation for more.
@@ -907,8 +907,8 @@ GAS is the GNU Assembler, that GCC relies upon.
 <para>
 Find it at the same place where you've found GCC, in the binutils package.
 The latest version of binutils is available from
-<ulink url="http://sources.redhat.com/binutils/">
-http://sources.redhat.com/binutils/</ulink>.
+<link xlink:href="http://sources.redhat.com/binutils/">
+http://sources.redhat.com/binutils/</link>.
 </para>
 </section>
 
@@ -1014,9 +1014,9 @@ see under <filename>linux/arch/i386/</filename> the following files:
 
 <para>
 If you are writing kind of a language, a thread package, etc., you might as
-well see how other languages (<ulink url="http://para.inria.fr/">
-OCaml</ulink>, <ulink url="http://www.jwdt.com/~paysan/gforth.html">
-Gforth</ulink>, etc.), or thread packages (QuickThreads, MIT pthreads,
+well see how other languages (<link xlink:href="http://para.inria.fr/">
+OCaml</link>, <link xlink:href="http://www.jwdt.com/~paysan/gforth.html">
+Gforth</link>, etc.), or thread packages (QuickThreads, MIT pthreads,
 LinuxThreads, etc), or whatever else do it.
 </para>
 
@@ -1035,8 +1035,8 @@ Good news are that starting from binutils 2.10 release, GAS supports Intel
 syntax too. It can be triggered with <literal>.intel_syntax</literal>
 directive. Unfortunately this mode is not documented (yet?) in the official
 binutils manual, so if you want to use it, try to examine
-<ulink url="http://www.lxhp.in-berlin.de/lhpas86.html">
-http://www.lxhp.in-berlin.de/lhpas86.html</ulink>, which is an extract from AMD
+<link xlink:href="http://www.lxhp.in-berlin.de/lhpas86.html">
+http://www.lxhp.in-berlin.de/lhpas86.html</link>, which is an extract from AMD
 64bit port of binutils 2.11.
 </para>
 </section>
@@ -1094,9 +1094,9 @@ formats.
 <title>Where to find NASM</title>
 
 <para>
-<ulink url="http://www.nasm.us">http://www.nasm.us</ulink>, 
-<ulink url="http://sourceforge.net/projects/nasm/">
-http://sourceforge.net/projects/nasm/</ulink>
+<link xlink:href="http://www.nasm.us">http://www.nasm.us</link>, 
+<link xlink:href="http://sourceforge.net/projects/nasm/">
+http://sourceforge.net/projects/nasm/</link>
 </para>
 
 <para>
@@ -1182,8 +1182,8 @@ ELKS continues to use it.
 
 <para>
 AS86 can be found at
-<ulink url="http://www.debath.co.uk/dev86/">
-http://www.debath.co.uk/dev86/</ulink>, in the bin86 package with linker (ld86),
+<link xlink:href="http://www.debath.co.uk/dev86/">
+http://www.debath.co.uk/dev86/</link>, in the bin86 package with linker (ld86),
 or as separate archive. Documentation is available as the man page and as.doc
 from the source package. When in doubt, the source code itself is often a good
 doc: though it is not very well commented, the programming style is
@@ -1242,7 +1242,7 @@ FASM (flat assembler) is a fast, efficient 80x86 assembler that runs in
 source code to include the information it really needs. It is written in itself
 and is very small and fast. It runs on DOS/Windows/Linux and can produce flat
 binary, DOS EXE, Win32 PE, COFF and Linux ELF output. See
-<ulink url="http://flatassembler.net">http://flatassembler.net</ulink>.
+<link xlink:href="http://flatassembler.net">http://flatassembler.net</link>.
 </para>
 </section>
 
@@ -1259,8 +1259,8 @@ and has various HLL-like extensions and programmer convenience commands.
 <para>
 It is (of course) slower than other assemblers. It has its own syntax (and uses
 its own names for x86 opcodes) Fairly good documentation is included. Check it
-out: <ulink url="ftp://linux01.gwdg.de/pub/cLIeNUX/interim/">
-ftp://linux01.gwdg.de/pub/cLIeNUX/interim/</ulink> (Access is password
+out: <link xlink:href="ftp://linux01.gwdg.de/pub/cLIeNUX/interim/">
+ftp://linux01.gwdg.de/pub/cLIeNUX/interim/</link> (Access is password
 controlled). You will probably not use it on regular basis, but at least it
 deserves your interest as an interesting idea.
 </para>
@@ -1293,8 +1293,8 @@ formats.
 </para>
 
 <para>
-<ulink url="http://savannah.nongnu.org/projects/aasm/">
-http://savannah.nongnu.org/projects/aasm/</ulink>
+<link xlink:href="http://savannah.nongnu.org/projects/aasm/">
+http://savannah.nongnu.org/projects/aasm/</link>
 </para>
 </section>
 
@@ -1309,8 +1309,8 @@ compilation process.
 </para>
 
 <para>
-It is available from <ulink url="http://www.penguin.cz/~niki/tdasm/">
-http://www.penguin.cz/~niki/tdasm/</ulink> but is seems it is no longer
+It is available from <link xlink:href="http://www.penguin.cz/~niki/tdasm/">
+http://www.penguin.cz/~niki/tdasm/</link> but is seems it is no longer
 actively maintained.
 </para>
 </section>
@@ -1319,8 +1319,8 @@ actively maintained.
 <title>HLA</title>
 
 <para>
-<ulink url="http://www.plantation-productions.com/Webster/HighLevelAsm/index.html">
-HLA</ulink> is a <emphasis>H</emphasis>igh <emphasis>L</emphasis>evel
+<link xlink:href="http://www.plantation-productions.com/Webster/HighLevelAsm/index.html">
+HLA</link> is a <emphasis>H</emphasis>igh <emphasis>L</emphasis>evel
 <emphasis>A</emphasis>ssembly language. It uses a high level language like
 syntax (similar to Pascal, C/C++, and other HLLs) for variable declarations,
 procedure declarations, and procedure calls. It uses a modified assembly
@@ -1341,7 +1341,7 @@ assembling and linking.
 <title>TALC</title>
 
 <para>
-<ulink url="http://www.cs.cornell.edu/talc/">TALC</ulink> is another free
+<link xlink:href="http://www.cs.cornell.edu/talc/">TALC</link> is another free
 MASM/Win32 based compiler (however it supports ELF output, does it?).
 </para>
 
@@ -1365,7 +1365,7 @@ extensible operating system kernels.
 <title>Free Pascal</title>
 
 <para>
-<ulink url="http://www.freepascal.org">Free Pascal</ulink> has an internal
+<link xlink:href="http://www.freepascal.org">Free Pascal</link> has an internal
 32-bit assembler (based on NASM tables) and a switchable output that allows:
 <itemizedlist>
 <listitem>
@@ -1427,8 +1427,8 @@ FORTH language. Macro processing is done with the full power of the reflective
 language FORTH; however, the only supported input and output contexts is
 Win32For itself (no dumping of <filename>.obj</filename> file, but you could
 add that feature yourself, of course). Find it at
-<ulink url="ftp://ftp.forth.org/pub/Forth/Compilers/native/windows/Win32For/">
-ftp://ftp.forth.org/pub/Forth/Compilers/native/windows/Win32For/</ulink>.
+<link xlink:href="ftp://ftp.forth.org/pub/Forth/Compilers/native/windows/Win32For/">
+ftp://ftp.forth.org/pub/Forth/Compilers/native/windows/Win32For/</link>.
 </para>
 </section>
 
@@ -1436,7 +1436,7 @@ ftp://ftp.forth.org/pub/Forth/Compilers/native/windows/Win32For/</ulink>.
 <title>Terse</title>
 
 <para>
-<ulink url="http://www.terse.com">Terse</ulink> is a programming tool that
+<link xlink:href="http://www.terse.com">Terse</link> is a programming tool that
 provides <emphasis>THE</emphasis> most compact assembler syntax for the x86
 family! However, it is evil proprietary software. It is said that there was a
 project for a free clone somewhere, that was abandoned after worthless pretenses
@@ -1447,7 +1447,7 @@ develop a terse-syntax frontend to NASM, if you like that syntax.
 
 <para>
 As an interesting historic remark, on
-<ulink url="news:comp.compilers">comp.compilers</ulink>,
+<link xlink:href="news:comp.compilers">comp.compilers</link>,
 </para>
 
 <para>
@@ -1561,8 +1561,8 @@ that CPP cannot.
 
 <para>
 See
-<ulink url="ftp://ftp.forth.org/pub/Forth/Compilers/native/unix/this4th.tar.gz">
-macro4th (this4th)</ulink> as an example of advanced macroprogramming using m4.
+<link xlink:href="ftp://ftp.forth.org/pub/Forth/Compilers/native/unix/this4th.tar.gz">
+macro4th (this4th)</link> as an example of advanced macroprogramming using m4.
 </para>
 
 <para>
@@ -1680,8 +1680,8 @@ There is a project, using the programming language Icon
 (with an experimental ML version),
 to build a basis for producing assembly-manipulating code.
 See around
-<ulink url="http://www.eecs.harvard.edu/~nr/toolkit/">
-http://www.eecs.harvard.edu/~nr/toolkit/</ulink>
+<link xlink:href="http://www.eecs.harvard.edu/~nr/toolkit/">
+http://www.eecs.harvard.edu/~nr/toolkit/</link>
 </para>
 </section>
 
@@ -1689,7 +1689,7 @@ http://www.eecs.harvard.edu/~nr/toolkit/</ulink>
 <title>TUNES</title>
 
 <para>
-The <ulink url="http://www.tunes.org">TUNES Project</ulink>
+The <link xlink:href="http://www.tunes.org">TUNES Project</link>
 for a Free Reflective Computing System is developing its own assembler
 as an extension to the Scheme language, as part of its development process.
 It doesn't run at all yet, though help is welcome.
@@ -1926,10 +1926,10 @@ Therefore, you might have to reimplement large parts of libc, from
 can be <emphasis>quite</emphasis> boring sometimes. Note that some people have
 already reimplemented "light" replacements for parts of the libc - - check
 them out! (Redhat's minilibc, Rick Hohensee's
-<ulink url="ftp://linux01.gwdg.de/pub/cLIeNUX/interim/libsys.tgz">libsys</ulink>,
-Felix von Leitner's <ulink url="http://www.fefe.de/dietlibc/">dietlibc</ulink>,
-<!-- Christian Fowelin's <ulink url="http://www.fowelin.de/christian/computer/libASM/">libASM</link>, -->
-<ulink url="http://asm.sourceforge.net/asmutils.html">asmutils</ulink>
+<link xlink:href="ftp://linux01.gwdg.de/pub/cLIeNUX/interim/libsys.tgz">libsys</link>,
+Felix von Leitner's <link xlink:href="http://www.fefe.de/dietlibc/">dietlibc</link>,
+<!-- Christian Fowelin's <link xlink:href="http://www.fowelin.de/christian/computer/libASM/">libASM</link>, -->
+<link xlink:href="http://asm.sourceforge.net/asmutils.html">asmutils</link>
 project is working on pure assembly libc)
 </para>
 </listitem>
@@ -2034,9 +2034,9 @@ previous Linux versions understand only 5 parameters in registers.
 </note>
 
 <para>
-<ulink url="http://www.tldp.org/LDP/lki/">Linux Kernel Internals</ulink>,
-and especially <ulink url="http://www.tldp.org/LDP/lki/lki-2.html#ss2.11">
-How System Calls Are Implemented on i386 Architecture?</ulink> chapter will give
+<link xlink:href="http://www.tldp.org/LDP/lki/">Linux Kernel Internals</link>,
+and especially <link xlink:href="http://www.tldp.org/LDP/lki/lki-2.html#ss2.11">
+How System Calls Are Implemented on i386 Architecture?</link> chapter will give
 you more robust overview.
 </para>
 
@@ -2068,8 +2068,8 @@ and documents from the LDP.
 
 <para>
 Particularly, if what you want is Graphics programming, then do join one of the
-<ulink url="http://www.ggi-project.org/">GGI</ulink> or
-<ulink url="http://www.XFree86.org/">XFree86</ulink> projects.
+<link xlink:href="http://www.ggi-project.org/">GGI</link> or
+<link xlink:href="http://www.XFree86.org/">XFree86</link> projects.
 </para>
 
 <para>
@@ -2092,7 +2092,7 @@ assembly source files.
 
 <para>
 Such thing is theoretically possible (proof: see how
-<ulink url="http://www.dosemu.org">DOSEMU</ulink> can selectively grant
+<link xlink:href="http://www.dosemu.org">DOSEMU</link> can selectively grant
 hardware port access to programs), and I've heard rumors that someone somewhere
 did actually do it (in the PCI driver? Some VESA access stuff? ISA PnP? dunno).
 If you have some more precise information on that, you'll be most welcome.
@@ -2165,8 +2165,8 @@ reflect the interrupt into the real-mode or vm86 handler).
 
 <para>
 Docs about DPMI (and much more) can be found on
-<ulink url="http://en.wikipedia.org/wiki/DOS_Protected_Mode_Interface">
-http://en.wikipedia.org/wiki/DOS_Protected_Mode_Interface</ulink>).
+<link xlink:href="http://en.wikipedia.org/wiki/DOS_Protected_Mode_Interface">
+http://en.wikipedia.org/wiki/DOS_Protected_Mode_Interface</link>).
 </para>
 
 <para>
@@ -2178,7 +2178,7 @@ derivative/subset/replacement, too.
 It is possible to cross-compile from Linux to DOS, see the
 <filename>devel/msdos/</filename> directory of your local FTP mirror for
 metalab.unc.edu; Also see the MOSS DOS-extender from the
-<ulink url="http://www.cs.utah.edu/projects/flux/">Flux project</ulink>
+<link xlink:href="http://www.cs.utah.edu/projects/flux/">Flux project</link>
 from the university of Utah.
 </para>
 
@@ -2192,7 +2192,7 @@ development.
 <para>
 This document is not about Windows programming, you can find lots of documents
 about it everywhere... The thing you should know is that there is the
-<ulink url="http://www.cygwin.com">cygwin32.dll library</ulink>,
+<link xlink:href="http://www.cygwin.com">cygwin32.dll library</link>,
 for GNU programs to run on Win32 platform; thus, you can use GCC, GAS,
 all the GNU tools, and many other Unix applications.
 </para>
@@ -2213,7 +2213,7 @@ an underlying system (much like Linux over Mach or OpenGenera over Unix).
 <para>
 Hence, for easier debugging purpose, you might like to develop your "OS" first
 as a process running on top of Linux (despite the slowness), then use the
-<ulink url="http://www.cs.utah.edu/projects/flux/oskit/">Flux OS kit</ulink>
+<link xlink:href="http://www.cs.utah.edu/projects/flux/oskit/">Flux OS kit</link>
 (which grants use of Linux and BSD drivers in your own OS) to make it
 stand-alone. When your OS is stable, it is time to write your own hardware
 drivers if you really love that.
@@ -2228,8 +2228,8 @@ braindeadness, defining your object format and calling conventions.
 <para>
 The main place where to find reliable information about that all, is source
 code of existing OSes and bootloaders. Lots of pointers are on the following
-webpage: <ulink url="http://www.tunes.org/Review/OSes.html">
-http://www.tunes.org/Review/OSes.html</ulink>
+webpage: <link xlink:href="http://www.tunes.org/Review/OSes.html">
+http://www.tunes.org/Review/OSes.html</link>
 </para>
 </section>
 </chapter>
@@ -2261,8 +2261,8 @@ and <command>gas</command>, thus showing Intel and AT&amp;T syntax.
 
 <para>
 You may also want to read
-<ulink url="http://asm.sourceforge.net/intro.html">
-Introduction to UNIX assembly programming</ulink> tutorial, it contains sample
+<link xlink:href="http://asm.sourceforge.net/intro.html">
+Introduction to UNIX assembly programming</link> tutorial, it contains sample
 code for other UNIX-like OSes.
 </para>
 
@@ -2525,8 +2525,8 @@ Your main resource for Linux/UNIX assembly programming material is:
 
 <blockquote>
 <para>
-<ulink url="http://asm.sourceforge.net/resources.html">
-http://asm.sourceforge.net/resources.html</ulink>
+<link xlink:href="http://asm.sourceforge.net/resources.html">
+http://asm.sourceforge.net/resources.html</link>
 </para>
 </blockquote>
 
@@ -2544,7 +2544,7 @@ If you are new to assembly in general, here are few starting pointers:
 <itemizedlist>
 <listitem>
 <para>
-<ulink url="http://savannah.nongnu.org/projects/pgubook/">Programming from the ground up</ulink>
+<link xlink:href="http://savannah.nongnu.org/projects/pgubook/">Programming from the ground up</link>
 </para>
 </listitem>
 
@@ -2556,7 +2556,7 @@ x86 assembly FAQ (use Google)
 
 <listitem>
 <para>
-<ulink url="http://www.koth.org">CoreWars</ulink>,
+<link xlink:href="http://www.koth.org">CoreWars</link>,
 a fun way to learn assembly in general
 </para>
 </listitem>
@@ -2564,8 +2564,8 @@ a fun way to learn assembly in general
 <listitem>
 <para>
 Usenet:
-<ulink url="news://comp.lang.asm.x86">comp.lang.asm.x86</ulink>;
-<ulink url="news://alt.lang.asm">alt.lang.asm</ulink>
+<link xlink:href="news://comp.lang.asm.x86">comp.lang.asm.x86</link>;
+<link xlink:href="news://alt.lang.asm">alt.lang.asm</link>
 </para>
 </listitem>
 </itemizedlist>
@@ -2602,8 +2602,8 @@ subscribe linux-assembly
 
 <para>
 Detailed information and list archives are available at
-<ulink url="http://asm.sourceforge.net/list.html">
-http://asm.sourceforge.net/list.html</ulink>.
+<link xlink:href="http://asm.sourceforge.net/list.html">
+http://asm.sourceforge.net/list.html</link>.
 </para>
 </simplesect>
 </chapter>
@@ -2630,7 +2630,7 @@ How do I do graphics programming in Linux?
 
 <answer>
 <para>
-An answer from <ulink url="mailto:paulf@gam.co.za">Paul Furber</ulink>:
+An answer from <link xlink:href="mailto:paulf@gam.co.za">Paul Furber</link>:
 </para>
 
 <para>
@@ -2698,7 +2698,7 @@ How do I debug pure assembly code under Linux?
 <answer>
 <para>
 There's an early version of the
-<ulink url="http://ald.sourceforge.net">Assembly Language Debugger</ulink>,
+<link xlink:href="http://ald.sourceforge.net">Assembly Language Debugger</link>,
 which is designed to work with assembly code,
 and is portable enough to run on Linux and *BSD.
 It is already functional and should be the right choice, check it out!
@@ -2711,7 +2711,7 @@ pure assembly code, and with some trickery you can make
 <command>gdb</command> to do what you need
 (unfortunately, nasm '-g' switch does not generate
 proper debug info for gdb; this is nasm bug, I think).
-Here's an answer from <ulink url="mailto:dl@gazeta.ru">Dmitry Bakhvalov</ulink>:
+Here's an answer from <link xlink:href="mailto:dl@gazeta.ru">Dmitry Bakhvalov</link>:
 </para>
 
 <para>
@@ -2767,7 +2767,7 @@ If you want to set breakpoints across your code, you can just use
 <para>
 If you're using <application>gas</application>, you should consult
 <application>gas</application> and <application>gdb</application> related
-<ulink url="http://asm.sourceforge.net/resources.html#tutorials">tutorials</ulink>.
+<link xlink:href="http://asm.sourceforge.net/resources.html#tutorials">tutorials</link>.
 </para>
 </answer>
 </qandaentry>
@@ -2897,7 +2897,7 @@ How do I allocate memory dynamically?
 
 <answer>
 <para>
-A laconic answer from <ulink url="mailto:phpr@snafu.de">H-Peter Recktenwald</ulink>:
+A laconic answer from <link xlink:href="mailto:phpr@snafu.de">H-Peter Recktenwald</link>:
 </para>
 
 <para>
@@ -2915,7 +2915,7 @@ A laconic answer from <ulink url="mailto:phpr@snafu.de">H-Peter Recktenwald</uli
 
 <answer>
 <para>
-An extensive answer from <ulink url="mailto:ee97034@fe.up.pt">Tiago Gasiba</ulink>:
+An extensive answer from <link xlink:href="mailto:ee97034@fe.up.pt">Tiago Gasiba</link>:
 </para>
 <para>
 <programlisting>
@@ -2983,7 +2983,7 @@ I can't understand how to use <function>select</function> system call!
 
 <answer>
 <para>
-An answer from <ulink url="mailto:mochel@transmeta.com">Patrick Mochel</ulink>:
+An answer from <link xlink:href="mailto:mochel@transmeta.com">Patrick Mochel</link>:
 </para>
 
 <para>
@@ -3544,7 +3544,7 @@ the following persons, by order of appearance:
 <itemizedlist>
 <listitem>
 <para>
-<ulink url="mailto:buried.alive@in.mail">Linus Torvalds</ulink>
+<link xlink:href="mailto:buried.alive@in.mail">Linus Torvalds</link>
 for Linux
 </para>
 </listitem>
@@ -3552,37 +3552,37 @@ for Linux
 <listitem>
 <para>
 <anchor xml:id="bde"/>
-<ulink url="mailto:bde@zeta.org.au">Bruce Evans</ulink>
+<link xlink:href="mailto:bde@zeta.org.au">Bruce Evans</link>
 for bcc from which as86 is extracted
 </para>
 </listitem>
 
 <listitem>
 <para>
-<ulink url="mailto:anakin@pobox.com">Simon Tatham</ulink> and
-<ulink url="mailto:jules@earthcorp.com">Julian Hall</ulink>
+<link xlink:href="mailto:anakin@pobox.com">Simon Tatham</link> and
+<link xlink:href="mailto:jules@earthcorp.com">Julian Hall</link>
 for NASM
 </para>
 </listitem>
 
 <listitem>
 <para>
-<ulink url="mailto:gregh@metalab.unc.edu">Greg Hankins</ulink> and now
-<ulink url="mailto:linux-howto@metalab.unc.edu">Tim Bynum</ulink>
+<link xlink:href="mailto:gregh@metalab.unc.edu">Greg Hankins</link> and now
+<link xlink:href="mailto:linux-howto@metalab.unc.edu">Tim Bynum</link>
 for maintaining HOWTOs
 </para>
 </listitem>
 
 <listitem>
 <para>
-<ulink url="mailto:raymoon@moonware.dgsys.com">Raymond Moon</ulink>
+<link xlink:href="mailto:raymoon@moonware.dgsys.com">Raymond Moon</link>
 for his FAQ
 </para>
 </listitem>
 
 <listitem>
 <para>
-<ulink url="mailto:dumas@linux.eu.org">Eric Dumas</ulink>
+<link xlink:href="mailto:dumas@linux.eu.org">Eric Dumas</link>
 for his translation of the mini-HOWTO into French
 (sad thing for the original author to be French and write in English)
 </para>
@@ -3590,22 +3590,22 @@ for his translation of the mini-HOWTO into French
 
 <listitem>
 <para>
-<ulink url="mailto:paul@geeky1.ebtech.net">Paul Anderson</ulink> and
-<ulink url="mailto:rahim@megsinet.net">Rahim Azizarab</ulink>
+<link xlink:href="mailto:paul@geeky1.ebtech.net">Paul Anderson</link> and
+<link xlink:href="mailto:rahim@megsinet.net">Rahim Azizarab</link>
 for helping me, if not for taking over the HOWTO
 </para>
 </listitem>
 
 <listitem>
 <para>
-<ulink url="mailto:pcg@goof.com">Marc Lehman</ulink>
+<link xlink:href="mailto:pcg@goof.com">Marc Lehman</link>
 for his insight on GCC invocation
 </para>
 </listitem>
 
 <listitem>
 <para>
-<ulink url="mailto:ams@wiw.org">Abhijit Menon-Sen</ulink>
+<link xlink:href="mailto:ams@wiw.org">Abhijit Menon-Sen</link>
 for helping me figure out the argument passing convention
 </para>
 </listitem>
@@ -4025,8 +4025,8 @@ Version 1.1, March 2000
     versions of the GNU Free Documentation License from time to time.
     Such new versions will be similar in spirit to the present
     version, but may differ in detail to address new problems or
-    concerns.  See <ulink url="http://www.gnu.org/copyleft/">
-    http://www.gnu.org/copyleft/</ulink>.</para>
+    concerns.  See <link xlink:href="http://www.gnu.org/copyleft/">
+    http://www.gnu.org/copyleft/</link>.</para>
 
     <para>Each version of the License is given a distinguishing
     version number.  If the Document specifies that a particular

--- a/LDP/howto/docbook/Assembly-HOWTO.xml
+++ b/LDP/howto/docbook/Assembly-HOWTO.xml
@@ -14,8 +14,8 @@
 
 <authorgroup>
 <author>
-<personname>
-<firstname><anchor xml:id="lnoor"/>Leo</firstname>
+<personname xml:id="lnoor">
+<firstname>Leo</firstname>
 <surname>Noordergraaf</surname>
 </personname>
 <affiliation>
@@ -29,8 +29,8 @@
 </author>
 
 <author>
-<personname>
-<firstname><anchor xml:id="konst"/>Konstantin</firstname>
+<personname xml:id="konst">
+<firstname>Konstantin</firstname>
 <surname>Boldyshev</surname>
 </personname>
 <affiliation>
@@ -44,8 +44,8 @@
 </author>
 
 <author>
-<personname>
-<firstname><anchor xml:id="fare"/>Francois-Rene</firstname>
+<personname xml:id="fare">
+<firstname>Francois-Rene</firstname>
 <surname>Rideau</surname>
 </personname>
 <affiliation>


### PR DESCRIPTION

This is our first DocBook 5.0 document.  It had a few very small validation errors, which I just corrected (am notifying Leo Nordergraaf via email).  Basically, I had to change the doctype declaration, add the appropriate XML namespaces on the root element and replace one DocBook element (<anchor/>) with the xml:id attribute.  Then, it validates and I can generate outputs.

-Martin