### PR TITLE
standardizing on lowercase <!doctype linuxdoc system

### DIFF
--- a/LDP/faq/linuxdoc/AfterStep-FAQ.sgml
+++ b/LDP/faq/linuxdoc/AfterStep-FAQ.sgml
@@ -1,4 +1,4 @@
-<!doctype Linuxdoc system>
+<!doctype linuxdoc system>
 
 <article>
 

--- a/LDP/faq/linuxdoc/PPP-FAQ.sgml
+++ b/LDP/faq/linuxdoc/PPP-FAQ.sgml
@@ -1,4 +1,4 @@
-<!DOCTYPE linuxdoc system>
+<!doctype linuxdoc system>
 
 <!-- Title information -->
 

--- a/LDP/howto/linuxdoc/CD-Writing-HOWTO.sgml
+++ b/LDP/howto/linuxdoc/CD-Writing-HOWTO.sgml
@@ -1,4 +1,4 @@
-<!doctype Linuxdoc system>
+<!doctype linuxdoc system>
 <article>
 
 <title>CD-Writing HOWTO

--- a/LDP/howto/linuxdoc/Call-back.sgml
+++ b/LDP/howto/linuxdoc/Call-back.sgml
@@ -1,4 +1,4 @@
-<!DOCTYPE LINUXDOC SYSTEM>
+<!doctype linuxdoc system>
 
 <ARTICLE>
 

--- a/LDP/howto/linuxdoc/Cluster-HOWTO.sgml
+++ b/LDP/howto/linuxdoc/Cluster-HOWTO.sgml
@@ -1,4 +1,4 @@
-<!doctype Linuxdoc system>
+<!doctype linuxdoc system>
 
 <article>
 

--- a/LDP/howto/linuxdoc/Config-HOWTO.sgml
+++ b/LDP/howto/linuxdoc/Config-HOWTO.sgml
@@ -1,4 +1,4 @@
-<!DOCTYPE LINUXDOC SYSTEM>
+<!doctype linuxdoc system>
 <!-- Initially generated from The_LDP_HOWTO_Generator V0.51 -->
 <article>
 

--- a/LDP/howto/linuxdoc/DPT-Hardware-RAID-HOWTO.sgml
+++ b/LDP/howto/linuxdoc/DPT-Hardware-RAID-HOWTO.sgml
@@ -1,4 +1,4 @@
-<!doctype Linuxdoc system>
+<!doctype linuxdoc system>
 
 <article>
 

--- a/LDP/howto/linuxdoc/Francophones-HOWTO.sgml
+++ b/LDP/howto/linuxdoc/Francophones-HOWTO.sgml
@@ -1,4 +1,4 @@
-<!doctype Linuxdoc system>
+<!doctype linuxdoc system>
 
 <article>
 

--- a/LDP/howto/linuxdoc/German-HOWTO.sgml
+++ b/LDP/howto/linuxdoc/German-HOWTO.sgml
@@ -1,4 +1,4 @@
-<!doctype Linuxdoc system>
+<!doctype linuxdoc system>
 
 <article>
 

--- a/LDP/howto/linuxdoc/Hellenic-HOWTO.sgml
+++ b/LDP/howto/linuxdoc/Hellenic-HOWTO.sgml
@@ -1,4 +1,4 @@
-<!DOCTYPE LINUXDOC SYSTEM>
+<!doctype linuxdoc system>
 <article>
 <title>HELLENIC HOWTO
 <author>

--- a/LDP/howto/linuxdoc/Jaz-Drive-HOWTO.sgml
+++ b/LDP/howto/linuxdoc/Jaz-Drive-HOWTO.sgml
@@ -1,4 +1,4 @@
-<!DOCTYPE LINUXDOC SYSTEM>
+<!doctype linuxdoc system>
 
 <!-- This file was created by my little fingers in Emacs -HSD -->
 

--- a/LDP/howto/linuxdoc/Kiosk-HOWTO.sgml
+++ b/LDP/howto/linuxdoc/Kiosk-HOWTO.sgml
@@ -1,4 +1,4 @@
-<!doctype Linuxdoc system>
+<!doctype linuxdoc system>
 <article>
 
 <title>Kiosk HOWTO <author>Gene Wilburn, ITS Dept, Royal Ontario

--- a/LDP/howto/linuxdoc/Linux+Solaris.sgml
+++ b/LDP/howto/linuxdoc/Linux+Solaris.sgml
@@ -1,4 +1,4 @@
-<!DOCTYPE LINUXDOC SYSTEM>
+<!doctype linuxdoc system>
 <linuxdoc>
 <article>
 <titlepag>

--- a/LDP/howto/linuxdoc/Loadlin+Win95-98-ME.sgml
+++ b/LDP/howto/linuxdoc/Loadlin+Win95-98-ME.sgml
@@ -1,4 +1,4 @@
-<!DOCTYPE LINUXDOC SYSTEM>
+<!doctype linuxdoc system>
 
 <ARTICLE>
 <TITLE>The Loadlin+Win95/98/ME mini-HOWTO

--- a/LDP/howto/linuxdoc/Mac-Terminal.sgml
+++ b/LDP/howto/linuxdoc/Mac-Terminal.sgml
@@ -1,4 +1,4 @@
-<!DOCTYPE LINUXDOC SYSTEM>
+<!doctype linuxdoc system>
 <article>
 
 <title> The MacTerminal MINI-HOWTO

--- a/LDP/howto/linuxdoc/RCS.sgml
+++ b/LDP/howto/linuxdoc/RCS.sgml
@@ -1,4 +1,4 @@
-<!DOCTYPE LINUXDOC SYSTEM>
+<!doctype linuxdoc system>
 <article>
 
 <title> The RCS MINI-HOWTO

--- a/LDP/howto/linuxdoc/Software-RAID-HOWTO.sgml
+++ b/LDP/howto/linuxdoc/Software-RAID-HOWTO.sgml
@@ -1,4 +1,4 @@
-<!DOCTYPE linuxdoc system
+<!doctype linuxdoc system
 [ <!ENTITY CurrentVer "1.1.1">
   <!ENTITY mdstat "<TT>/proc/mdstat</TT>">
   <!ENTITY ftpkernel "<TT>ftp://ftp.fi.kernel.org/pub/linux</TT>">

--- a/LDP/howto/linuxdoc/Wacom-Tablet-HOWTO.sgml
+++ b/LDP/howto/linuxdoc/Wacom-Tablet-HOWTO.sgml
@@ -1,4 +1,4 @@
-<!DOCTYPE linuxdoc system>
+<!doctype linuxdoc system>
 <!-- 
 Wacom Tablet HOWTO, (C) 1999 by <SR>
 ------------------------------------

--- a/LDP/howto/linuxdoc/Web-Browsing-Behind-ISA-Server-HOWTO.sgml
+++ b/LDP/howto/linuxdoc/Web-Browsing-Behind-ISA-Server-HOWTO.sgml
@@ -1,4 +1,4 @@
-<!DOCTYPE LINUXDOC SYSTEM>
+<!doctype linuxdoc system>
 
 <!-- 
      Web Browsing behind ISA Server using linux based browsers.


### PR DESCRIPTION
This makes automatic detection of filetype a bit easier and a bit safer.

Choosing a convention here also prevents the need for special-case logic to handle either Linuxdoc or the various DocBook formats.  The same case-sensitive logic can apply for detecting the document signature string.

-Martin