### PR TITLE
Removing Warning mplicit declaration of built-in function

### DIFF
--- a/LDP/howto/docbook/NCURSES-Programming-HOWTO/resources/ncurses_programs/JustForFun/tt.c
+++ b/LDP/howto/docbook/NCURSES-Programming-HOWTO/resources/ncurses_programs/JustForFun/tt.c
@@ -1,5 +1,6 @@
 #include <curses.h>
 #include <stdio.h>
+#include <string.h>
 #include <stdlib.h>
 #include <time.h>
 


### PR DESCRIPTION
On gcc v4 and above it gives warning implicit declaration of built-in function 'strcpy' and 'strlen' , i think it needs string.h included there