### PR TITLE
fix(howto/linuxdoc): fix broken link in Emacs-Beginner-HOWTO

### DIFF
--- a/LDP/howto/linuxdoc/Emacs-Beginner-HOWTO.sgml
+++ b/LDP/howto/linuxdoc/Emacs-Beginner-HOWTO.sgml
@@ -593,8 +593,8 @@ included in the Emacs distribution. This mode is called either
 <tt>cc-mode</tt> or <tt>CC Mode</tt>.
 
 <p>For more details or to download a newer version, visit <htmlurl
-url="http://www.python.org/emacs/"
-name="http://www.python.org/emacs/">.
+url="http://cc-mode.sourceforge.net/"
+name="http://cc-mode.sourceforge.net/">.
 
 </sect2>
 


### PR DESCRIPTION
The link in the CC Mode section points to a broken python.com instead of the real CC Mode website