### PR TITLE
No rule to make target "syscall_32.tbl"

### DIFF
--- a/LDP/guide/docbook/lkmpg-2.6/lkmpg-examples/02-HelloWorld/Makefile
+++ b/LDP/guide/docbook/lkmpg-2.6/lkmpg-examples/02-HelloWorld/Makefile
@@ -7,7 +7,7 @@ obj-m += startstop.o
 startstop-objs := start.o stop.o
 
 all:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+	make -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) modules
 
 clean:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+	make -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) clean

--- a/LDP/guide/docbook/lkmpg-2.6/lkmpg-examples/02-HelloWorld/Makefile.1
+++ b/LDP/guide/docbook/lkmpg-2.6/lkmpg-examples/02-HelloWorld/Makefile.1
@@ -1,7 +1,7 @@
 obj-m += hello-1.o
 
 all:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+	make -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) modules
 
 clean:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+	make -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) clean

--- a/LDP/guide/docbook/lkmpg-2.6/lkmpg-examples/02-HelloWorld/Makefile.2
+++ b/LDP/guide/docbook/lkmpg-2.6/lkmpg-examples/02-HelloWorld/Makefile.2
@@ -2,7 +2,7 @@ obj-m += hello-1.o
 obj-m += hello-2.o
 
 all:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+	make -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) modules
 
 clean:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+	make -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) clean


### PR DESCRIPTION
 M=$(PWD) would have worked if PWD had been defined in the shell before. But this is not the case,so need to replace it with M=$(shell pwd) .