### PR TITLE
fix broken link

### DIFF
--- a/LDP/guide/docbook/sag/ch07.sgml
+++ b/LDP/guide/docbook/sag/ch07.sgml
@@ -276,7 +276,7 @@ CPU
 <title>Finding More Utilities</title>
 	<para>To learn more about what command line tools are available, Chris 
 	Karakas has wrote a reference guide titled <ulink 
-	url="http://www.karakas-online.de/gnu-linux-tools-summary/"> GNU/Linux 
+	url="http://www.tldp.org/LDP/GNU-Linux-Tools-Summary/html/GNU-Linux-Tools-Summary.html"> GNU/Linux 
 	Command-Line Tools Summary</ulink>.  It's a good resource for learning
 	what tools are out there and how to do a number of tasks.</para>
 </sect2>


### PR DESCRIPTION
Point to the "GNU/Linux Command-Line Tools Summary" guide on TLDP instead of karakas-online.de, which is down, fixing the broken link.