### PR TITLE
Use tar -z for gzip instead tar -Z for compress

### DIFF
--- a/LDP/howto/linuxdoc/Bash-Prog-Intro-HOWTO.sgml
+++ b/LDP/howto/linuxdoc/Bash-Prog-Intro-HOWTO.sgml
@@ -101,7 +101,7 @@ Very simple Scripts
         <P>
 	<tscreen><verb>
 	#!/bin/bash
-	tar -cZf /var/my-backup.tgz /home/me/
+	tar -czf /var/my-backup.tgz /home/me/
 	</verb></tscreen>
         <P> In this script, instead of printing a message on the terminal,
 	we create a tar-ball of a user's home directory. This is NOT intended
@@ -298,7 +298,7 @@ Variables
 	   <tscreen><verb>
 	   #!/bin/bash
 	   OF=/var/my-backup-$(date +%Y%m%d).tgz
-	   tar -cZf $OF /home/me/
+	   tar -czf $OF /home/me/
 	   </verb></tscreen>
 	   <P> This script introduces another thing. First
 	   of all, you should be familiarized with the variable
@@ -609,7 +609,7 @@ User interfaces
           SRCD=$1
           TGTD="/var/backups/"
           OF=home-$(date +%Y%m%d).tgz
-          tar -cZf $TGTD$OF $SRCD
+          tar -czf $TGTD$OF $SRCD
 	 </verb></tscreen>
 	 <P>
 	 <P> What this script does should be clear to you. The expression
@@ -964,7 +964,7 @@ More Scripts
 	    SRCD="/home/"
 	    TGTD="/var/backups/"
 	    OF=home-$(date +%Y%m%d).tgz
-	    tar -cZf $TGTD$OF $SRCD
+	    tar -czf $TGTD$OF $SRCD
 	   </verb></tscreen>
 	   <P>
      </sect1>


### PR DESCRIPTION
Hello,
this small contribution is here to replace tar -cZf (that uses compress) for tar -zcf (using gzip).
Compress is not being installed by default and gzip has better compression ratio.
Thank You