### PR TITLE
Updated Autodir-HOWTO.xml with reference to new author and  pointers to information. 

### DIFF
--- a/LDP/howto/docbook/Autodir-HOWTO.xml
+++ b/LDP/howto/docbook/Autodir-HOWTO.xml
@@ -9,6 +9,17 @@
 
     <!-- Use "HOWTO", "mini HOWTO", "FAQ" in title, if appropriate -->
     <title>Autodir HOWTO</title>
+
+    <authorgroup>
+    <author>
+       <firstname>Francesco Paolo</firstname>
+       <surname>Lovergine</surname>
+       <affiliation>
+          <orgname>Debian Project</orgname>
+          <!-- Valid email...spamblock/scramble if so desired -->
+          <address><email>frankie &lt;&gt; debian dot com</email></address>
+       </affiliation>
+     </author>
     <author>
        <firstname>Venkata Ramana</firstname>
        <surname>Enaganti</surname>
@@ -17,6 +28,7 @@
           <address><email>ramana &lt;&gt; intraperson dot com</email></address>
        </affiliation>
      </author>
+    </authorgroup>
     <editor>
        <firstname>Rahul</firstname>
        <surname>Sundaram</surname>
@@ -27,10 +39,16 @@
     </editor>
 
      <!-- All dates specified in ISO "YYYY-MM-DD" format -->
-     <pubdate>2004-09-23</pubdate>
+     <pubdate>2023-12-23</pubdate>
 
      <!-- Most recent revision goes at the top; list in descending order -->
      <revhistory id="revhistory">
+       <revision>
+          <revnumber>1.05</revnumber>
+          <date>2023-12-23</date>
+          <authorinitials>FPL</authorinitials>
+          <revremark>Review requested by current maintainer</revremark>
+       </revision>
        <revision>
           <revnumber>1.04</revnumber>
           <date>2007-5-25</date>
@@ -138,12 +156,12 @@ This work is licensed under the Creative Commons Attribution License. To view a 
     <para>
      Feedback is most certainly welcome for this document. Send
      your additions, comments and criticisms to the following
-     email address : <email>ramana &lt;&gt; intraperson dot com</email>.
+     email address : <email>frankie &lt;&gt; debian dot org</email>.
     </para>
   </sect2>
   <sect2>
     <title>New Versions of this Document</title>
-	<para>The latest version of this HOWTO will be made available from <ulink url="http://www.intraperson.com/autodir/">http://www.intraperson.com/autodir/</ulink>.</para>
+    <para>The latest version of this HOWTO will be made available from <ulink url="https://github.com/fpl/autodir/">https://github.com/fpl/autodir/</ulink>.</para>
   </sect2>
   <sect2 id="credits">
     <title>Credits / Contributors</title>
@@ -181,9 +199,9 @@ This work is licensed under the Creative Commons Attribution License. To view a 
 <sect1>
 	<title>Before going into the details...</title>
 
-<para>After releasing intraperson beta, I started working on a administration guide that deals with the administration aspects of <emphasis role="bold">intraPerson</emphasis>. For more details check <ulink url="http://www.intraperson.com" />. But I was stuck with one simple thing. It is easy to create users in LDAP - at least I think so - but how to create home directories for those users in LDAP wherever those LDAP accounts are imported?</para>
+<para>After releasing his software intraperson beta, Ramana started working on a administration guide that deals with the administration aspects of <emphasis role="bold">intraPerson</emphasis>. But he was stuck with one simple thing. It is easy to create users in LDAP - at least I think so - but how to create home directories for those users in LDAP wherever those LDAP accounts are imported?</para>
 
-<para>I found some solutions, but I was not satisfied as every solution has serious drawbacks.  After leafing through the Autofs documents and hacking a bit, I came to the conclusion that the Autofs protocol might offer a much better solution to this challenge.</para>
+<para>Ramana found some solutions, but he was not satisfied as every solution has serious drawbacks.  After leafing through the Autofs documents and hacking a bit, he came to the conclusion that the Autofs protocol might offer a much better solution to this challenge.</para>
 
 <para>The result is <emphasis role="bold">Autodir</emphasis>, based on the Autofs protocol.</para>
 
@@ -468,7 +486,7 @@ This work is licensed under the Creative Commons Attribution License. To view a 
 <sect1>
 	<title>Getting Autodir</title>
 
-<para>At this moment <emphasis role="bold">Autodir</emphasis> is available in tar and rpm formats. More information can be found at <ulink url="http://www.intraperson.com/autodir/">http://www.intraperson.com/autodir/</ulink>.</para>
+    <para>At this moment <emphasis role="bold">Autodir</emphasis> is available in the main archive of Debian GNU/Linux and all its derivative distribution, including Ubuntu. Source repository is hosted on Github at <ulink url="https://github.com/fpl/autodir/">https://github.com/fpl/autodir/</ulink>.</para>
 
 <para>After downloading the source, follow these simple steps to install :</para>
 
@@ -729,9 +747,7 @@ For example: <command>autodir <option>-d</option> <filename>homedir</filename> <
 <sect1 id="moreinfo">
 	<title>Further Information</title>
 <itemizedlist>
-<listitem><para><emphasis role="bold">Mailing list for autodir </emphasis><ulink url="http://lists.sourceforge.net/mailman/listinfo/intraperson-autodir">http://lists.sourceforge.net/mailman/listinfo/intraperson-autodir</ulink>.</para></listitem>
-
-<listitem><para>Official website is at <ulink url="http://www.intraperson.com/autodir/">http://www.intraperson.com/autodir/</ulink>.</para></listitem>
+    <listitem><para>Official website is at <ulink url="https://github.com/fpl/autodir/">https://github.com/fpl/autodir/</ulink>.</para></listitem>
 
 <listitem><para>Autofs mailing list <ulink url="http://linux.kernel.org/mailman/listinfo/autofs">http://linux.kernel.org/mailman/listinfo/autofs</ulink>.</para></listitem>
 

--- a/LDP/howto/docbook/Autodir-HOWTO.xml
+++ b/LDP/howto/docbook/Autodir-HOWTO.xml
@@ -17,7 +17,7 @@
        <affiliation>
           <orgname>Debian Project</orgname>
           <!-- Valid email...spamblock/scramble if so desired -->
-          <address><email>frankie &lt;&gt; debian dot com</email></address>
+          <address><email>frankie &lt;&gt; debian dot org</email></address>
        </affiliation>
      </author>
     <author>


### PR DESCRIPTION
Hi, after years, I finally decided to adopt the Autodir code, for which this how-to has been conceived by the original author (who, at a certain point in time, stepped down from the role). I'm also the Debian maintainer of the package for `autodir`, and it would be nice to update the information available on the howto to reflect the current status because it is still quite difficult finding the new repository on GitHub, and the whole process would require other years to be finalized.
I hope in a fast review process :-) 

The new repo is available [here](https://github.com/fpl/autodir)